### PR TITLE
Add appStartInfo to a public API

### DIFF
--- a/PerformanceSuite/Sources/PerformanceMonitoring.swift
+++ b/PerformanceSuite/Sources/PerformanceMonitoring.swift
@@ -103,6 +103,12 @@ public enum PerformanceMonitoring {
         }
     }
 
+
+    /// The information about the recent app start
+    public static var appStartInfo: AppStartInfo {
+        return AppInfoHolder.appStartInfo
+    }
+
     private static func appendTTIObservers(config: Config, vcObservers: inout [ViewControllerObserver]) {
         guard let screenTTIReceiver = config.screenTTIReceiver else {
             return

--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -37,6 +37,20 @@ final class PerformanceMonitoringTests: XCTestCase {
         let vc2 = UIViewController()
         wait(for: [exp2], timeout: 0.5)
         _ = vc2
+
+        let appStartInfo = PerformanceMonitoring.appStartInfo
+        XCTAssertFalse(appStartInfo.appStartedWithPrewarming)
+    }
+
+    func testPrewarming() throws {
+        setenv("ActivePrewarm", "1", 1)
+        PerformanceMonitoring.onMainStarted()
+        try PerformanceMonitoring.enable(config: .all(receiver: self))
+
+        XCTAssertTrue(PerformanceMonitoring.appStartInfo.appStartedWithPrewarming)
+
+        try PerformanceMonitoring.disable()
+        setenv("ActivePrewarm", "", 1)
     }
 
     private var onInitExpectation: XCTestExpectation?


### PR DESCRIPTION
You can now access `PerformanceMonitoring.appStartInfo` property with the prewarming information there. 