### PR TITLE
Introduce typed identifiers for screen level metric receivers

### DIFF
--- a/PerformanceSuite/PerformanceApp/MetricsConsumer.swift
+++ b/PerformanceSuite/PerformanceApp/MetricsConsumer.swift
@@ -25,25 +25,18 @@ class MetricsConsumer: PerformanceSuiteMetricsReceiver {
         interop?.send(message: Message.appFreezeTime(duration: metrics.freezeTime.milliseconds ?? -1))
     }
 
-    func ttiMetricsReceived(metrics: TTIMetrics, viewController: UIViewController) {
-        guard let screen = (viewController as? PerformanceTrackable)?.performanceScreen?.rawValue else {
-            fatalError("unknown screen")
-        }
-
+    func ttiMetricsReceived(metrics: TTIMetrics, screen: PerformanceScreen) {
         log("TTIMetrics \(screen) \(metrics)")
-        interop?.send(message: Message.tti(duration: metrics.tti.milliseconds ?? -1, screen: screen))
+        interop?.send(message: Message.tti(duration: metrics.tti.milliseconds ?? -1, screen: screen.rawValue))
     }
 
-    func renderingMetricsReceived(metrics: RenderingMetrics, viewController: UIViewController) {
-        guard let screen = (viewController as? PerformanceTrackable)?.performanceScreen?.rawValue else {
-            fatalError("unknown screen")
-        }
+    func renderingMetricsReceived(metrics: RenderingMetrics, screen: PerformanceScreen) {
         log("RenderingMetrics \(screen) \(metrics)")
-        interop?.send(message: Message.freezeTime(duration: metrics.freezeTime.milliseconds ?? -1, screen: screen))
+        interop?.send(message: Message.freezeTime(duration: metrics.freezeTime.milliseconds ?? -1, screen: screen.rawValue))
     }
 
-    func shouldTrack(viewController: UIViewController) -> Bool {
-        return (viewController as? PerformanceTrackable)?.performanceScreen != nil
+    func screenIdentifier(for viewController: UIViewController) -> PerformanceScreen? {
+        return (viewController as? PerformanceTrackable)?.performanceScreen
     }
 
     func watchdogTerminationReceived(_ data: WatchdogTerminationData) {
@@ -61,7 +54,7 @@ class MetricsConsumer: PerformanceSuiteMetricsReceiver {
         interop?.send(message: Message.startupTime(duration: data.totalTime.milliseconds ?? -1))
     }
 
-    func fragmentTTIMetricsReceived(metrics: TTIMetrics, identifier: String) {
+    func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment identifier: String) {
         log("fragmentTTIMetricsReceived \(identifier) \(metrics)")
         interop?.send(message: Message.fragmentTTI(duration: metrics.tti.milliseconds ?? -1, fragment: identifier))
     }
@@ -88,31 +81,27 @@ class MetricsConsumer: PerformanceSuiteMetricsReceiver {
 
     // MARK: - ViewControllerLoggingReceiver
 
-    func key(for viewController: UIViewController) -> String {
-        return String(describing: viewController)
+    func onInit(screen: PerformanceScreen) {
+        log("onInit \(screen)")
     }
 
-    func onInit(viewControllerKey: String) {
-        log("onInit \(viewControllerKey)")
+    func onViewDidLoad(screen: PerformanceScreen) {
+        log("onViewDidLoad \(screen)")
     }
 
-    func onViewDidLoad(viewControllerKey: String) {
-        log("onViewDidLoad \(viewControllerKey)")
+    func onViewWillAppear(screen: PerformanceScreen) {
+        log("onViewWillAppear \(screen)")
     }
 
-    func onViewWillAppear(viewControllerKey: String) {
-        log("onViewWillAppear \(viewControllerKey)")
+    func onViewDidAppear(screen: PerformanceScreen) {
+        log("onViewDidAppear \(screen)")
     }
 
-    func onViewDidAppear(viewControllerKey: String) {
-        log("onViewDidAppear \(viewControllerKey)")
+    func onViewWillDisappear(screen: PerformanceScreen) {
+        log("onViewWillDisappear \(screen)")
     }
 
-    func onViewWillDisappear(viewControllerKey: String) {
-        log("onViewWillDisappear \(viewControllerKey)")
-    }
-
-    func onViewDidDisappear(viewControllerKey: String) {
-        log("onViewDidDisappear \(viewControllerKey)")
+    func onViewDidDisappear(screen: PerformanceScreen) {
+        log("onViewDidDisappear \(screen)")
     }
 }

--- a/PerformanceSuite/Sources/Config.swift
+++ b/PerformanceSuite/Sources/Config.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 public enum ConfigItem {
-    case screenLevelTTI(TTIMetricsReceiver)
-    case screenLevelRendering(RenderingMetricsReceiver)
+    case screenLevelTTI(any TTIMetricsReceiver)
+    case screenLevelRendering(any RenderingMetricsReceiver)
     case appLevelRendering(AppRenderingMetricsReceiver)
     case startupTime(StartupTimeReceiver)
     case watchdogTerminations(WatchdogTerminationsReceiver)
     case hangs(HangsReceiver)
     case viewControllerLeaks(ViewControllerLeaksReceiver)
-    case logging(ViewControllerLoggingReceiver)
-    case fragmentTTI(FragmentTTIMetricsReceiver)
+    case logging(any ViewControllerLoggingReceiver)
+    case fragmentTTI(any FragmentTTIMetricsReceiver)
 }
 
 public typealias Config = [ConfigItem]
@@ -56,7 +56,7 @@ extension Config {
         return result
     }
 
-    var screenTTIReceiver: TTIMetricsReceiver? {
+    var screenTTIReceiver: (any TTIMetricsReceiver)? {
         findReceiver(title: "screenLevelTTI") { item in
             if case .screenLevelTTI(let result) = item {
                 return result
@@ -66,7 +66,7 @@ extension Config {
         }
     }
 
-    var screenRenderingReceiver: RenderingMetricsReceiver? {
+    var screenRenderingReceiver: (any RenderingMetricsReceiver)? {
         findReceiver(title: "screenLevelRendering") { item in
             if case .screenLevelRendering(let result) = item {
                 return result
@@ -126,7 +126,7 @@ extension Config {
         }
     }
 
-    var loggingReceiver: ViewControllerLoggingReceiver? {
+    var loggingReceiver: (any ViewControllerLoggingReceiver)? {
         findReceiver(title: "logging") { item in
             if case .logging(let result) = item {
                 return result
@@ -136,7 +136,7 @@ extension Config {
         }
     }
 
-    var fragmentTTIReceiver: FragmentTTIMetricsReceiver? {
+    var fragmentTTIReceiver: (any FragmentTTIMetricsReceiver)? {
         findReceiver(title: "fragmentTTI") { item in
             if case .fragmentTTI(let result) = item {
                 return result
@@ -146,7 +146,7 @@ extension Config {
         }
     }
 
-    public static func all(receiver: PerformanceSuiteMetricsReceiver) -> Self {
+    public static func all(receiver: any PerformanceSuiteMetricsReceiver) -> Self {
         [
             .screenLevelTTI(receiver),
             .screenLevelRendering(receiver),

--- a/PerformanceSuite/Sources/StartupTimeReporter.swift
+++ b/PerformanceSuite/Sources/StartupTimeReporter.swift
@@ -234,4 +234,6 @@ final class StartupTimeViewControllerObserver: ViewControllerObserver {
     func afterViewWillAppear(viewController: UIViewController) {}
     func beforeViewWillDisappear(viewController: UIViewController) {}
     func beforeViewDidDisappear(viewController: UIViewController) {}
+
+    static let identifier: AnyObject = NSObject()
 }

--- a/PerformanceSuite/Sources/TTIObserver+Extensions.swift
+++ b/PerformanceSuite/Sources/TTIObserver+Extensions.swift
@@ -29,7 +29,7 @@ public extension UIViewController {
     /// }
     /// ```
     @objc func screenIsReady() {
-        let observer = ViewControllerObserverFactory<TTIObserver>.existingObserver(for: self)
+        let observer = ViewControllerObserverFactoryHelper.existingObserver(for: self, identifier: TTIObserverHelper.identifier) as? ScreenIsReadyProvider
         observer?.screenIsReady()
     }
 
@@ -45,14 +45,14 @@ public extension UIViewController {
     /// For example, when you create UIViewController and cache it in some property earlier then showing it.
     /// Then you call this method before actually showing this controller.
     @objc static func screenIsBeingCreated() {
-        TTIObserver.startCustomCreationTime()
+        TTIObserverHelper.startCustomCreationTime()
     }
 
 
     /// Call this method in case you called `screenIsBeingCreated`, but screen won't be created.
     /// For example network request failed, or user tapped `cancel` or so on.
     @objc static func screenCreationCancelled() {
-        TTIObserver.clearCustomCreationTime()
+        TTIObserverHelper.clearCustomCreationTime()
     }
 }
 

--- a/PerformanceSuite/Sources/ViewControllerLeaksObserver.swift
+++ b/PerformanceSuite/Sources/ViewControllerLeaksObserver.swift
@@ -107,6 +107,8 @@ final class ViewControllerLeaksObserver: ViewControllerObserver {
         }
     }
 
+    static let identifier: AnyObject = NSObject()
+
     // MARK: - Helpers
 
     private func selfAndAllChildren(viewController: UIViewController) -> [UIViewController] {

--- a/PerformanceSuite/Tests/FragmentTTIReporterTests.swift
+++ b/PerformanceSuite/Tests/FragmentTTIReporterTests.swift
@@ -230,7 +230,7 @@ final class FragmentTTIReporterTests: XCTestCase {
 }
 
 private class FragmentTTIMetricsReceiverStub: FragmentTTIMetricsReceiver {
-    func fragmentTTIMetricsReceived(metrics: TTIMetrics, identifier: String) {
+    func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment identifier: String) {
         self.identifier = identifier
         self.metrics = metrics
     }

--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -29,7 +29,7 @@ final class PerformanceMonitoringTests: XCTestCase {
         let exp = expectation(description: "onInit")
         onInitExpectation = exp
         let vc = UIViewController()
-        wait(for: [exp], timeout: 5)
+        wait(for: [exp], timeout: 20) // increase timeout as it is very slow on CI
         _ = vc
         try PerformanceMonitoring.disable()
 
@@ -59,11 +59,17 @@ final class PerformanceMonitoringTests: XCTestCase {
 }
 
 extension PerformanceMonitoringTests: PerformanceSuiteMetricsReceiver {
+    typealias ScreenIdentifier = String
+
+    func screenIdentifier(for viewController: UIViewController) -> String? {
+        return String(describing: type(of: viewController))
+    }
+
     func appRenderingMetricsReceived(metrics: PerformanceSuite.RenderingMetrics) {
 
     }
 
-    func fragmentTTIMetricsReceived(metrics: PerformanceSuite.TTIMetrics, identifier: String) {
+    func fragmentTTIMetricsReceived(metrics: PerformanceSuite.TTIMetrics, fragment identifier: String) {
 
     }
 
@@ -78,39 +84,35 @@ extension PerformanceMonitoringTests: PerformanceSuiteMetricsReceiver {
     func hangStarted(info: PerformanceSuite.HangInfo) {
     }
 
-    func renderingMetricsReceived(metrics: PerformanceSuite.RenderingMetrics, viewController: UIViewController) {
+    func renderingMetricsReceived(metrics: PerformanceSuite.RenderingMetrics, screen: String) {
     }
 
     func startupTimeReceived(_ data: PerformanceSuite.StartupTimeData) {
     }
 
-    func ttiMetricsReceived(metrics: PerformanceSuite.TTIMetrics, viewController: UIViewController) {
+    func ttiMetricsReceived(metrics: PerformanceSuite.TTIMetrics, screen: String) {
     }
 
     func viewControllerLeakReceived(viewController: UIViewController) {
     }
 
-    func key(for viewController: UIViewController) -> String {
-        return String(describing: type(of: viewController))
-    }
-
-    func onInit(viewControllerKey: String) {
+    func onInit(screen: String) {
         onInitExpectation?.fulfill()
     }
 
-    func onViewDidLoad(viewControllerKey: String) {
+    func onViewDidLoad(screen: String) {
     }
 
-    func onViewWillAppear(viewControllerKey: String) {
+    func onViewWillAppear(screen: String) {
     }
 
-    func onViewDidAppear(viewControllerKey: String) {
+    func onViewDidAppear(screen: String) {
     }
 
-    func onViewWillDisappear(viewControllerKey: String) {
+    func onViewWillDisappear(screen: String) {
     }
 
-    func onViewDidDisappear(viewControllerKey: String) {
+    func onViewDidDisappear(screen: String) {
     }
 
     func watchdogTerminationReceived(_ data: PerformanceSuite.WatchdogTerminationData) {

--- a/PerformanceSuite/Tests/RenderingObserverTests.swift
+++ b/PerformanceSuite/Tests/RenderingObserverTests.swift
@@ -31,7 +31,7 @@ class RenderingObserverTests: XCTestCase {
     func testRenderingObserver() {
         let metricsReceiver = RenderingMetricsReceiverStub()
         let framesMeter = FramesMeterStub()
-        let observer = RenderingObserver(metricsReceiver: metricsReceiver, framesMeter: framesMeter)
+        let observer = RenderingObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, framesMeter: framesMeter)
 
         let vc = UIViewController()
 
@@ -97,7 +97,7 @@ class RenderingObserverTests: XCTestCase {
     func testRenderingObserverIsResetAfterViewDisappeared() {
         let metricsReceiver = RenderingMetricsReceiverStub()
         let framesMeter = FramesMeterStub()
-        let observer = RenderingObserver(metricsReceiver: metricsReceiver, framesMeter: framesMeter)
+        let observer = RenderingObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, framesMeter: framesMeter)
 
         let vc = UIViewController()
 
@@ -174,18 +174,18 @@ class FramesMeterStub: FramesMeter {
 
 class RenderingMetricsReceiverStub: RenderingMetricsReceiver {
 
-    func renderingMetricsReceived(metrics: RenderingMetrics, viewController: UIViewController) {
+    func renderingMetricsReceived(metrics: RenderingMetrics, screen viewController: UIViewController) {
         renderingCallback(metrics, viewController)
         renderingMetrics = metrics
         lastController = viewController
     }
 
-    func shouldTrack(viewController: UIViewController) -> Bool {
+    func screenIdentifier(for viewController: UIViewController) -> UIViewController? {
         if viewController is UINavigationController
             || viewController is UITabBarController {
-            return false
+            return nil
         }
-        return true
+        return viewController
     }
 
     var renderingCallback: (RenderingMetrics, UIViewController) -> Void = { (_, _) in }

--- a/PerformanceSuite/Tests/TTIObserverTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverTests.swift
@@ -31,22 +31,22 @@ class TTIObserverTests: XCTestCase {
     func testTTIObserverForViewController() throws {
         let vc1 = UIViewController()
         waitForTheNextRunLoop()
-        XCTAssertNil(ViewControllerObserverFactory<TTIObserver>.existingObserver(for: vc1))
+        XCTAssertNil(ViewControllerObserverFactoryHelper.existingObserver(for: vc1, identifier: TTIObserverHelper.identifier))
 
         try PerformanceMonitoring.enable(config: [.screenLevelTTI(TTIMetricsReceiverStub())])
         let vc2 = UIViewController()
         waitForTheNextRunLoop()
-        XCTAssertNotNil(ViewControllerObserverFactory<TTIObserver>.existingObserver(for: vc2))
+        XCTAssertNotNil(ViewControllerObserverFactoryHelper.existingObserver(for: vc2, identifier: TTIObserverHelper.identifier))
 
         try PerformanceMonitoring.disable()
         let vc3 = UIViewController()
         waitForTheNextRunLoop()
-        XCTAssertNil(ViewControllerObserverFactory<TTIObserver>.existingObserver(for: vc3))
+        XCTAssertNil(ViewControllerObserverFactoryHelper.existingObserver(for: vc3, identifier: TTIObserverHelper.identifier))
 
         try PerformanceMonitoring.enable(config: [])
         let vc4 = UIViewController()
         waitForTheNextRunLoop()
-        XCTAssertNil(ViewControllerObserverFactory<TTIObserver>.existingObserver(for: vc4))
+        XCTAssertNil(ViewControllerObserverFactoryHelper.existingObserver(for: vc4, identifier: TTIObserverHelper.identifier))
         try PerformanceMonitoring.disable()
     }
 
@@ -56,7 +56,7 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
 
         observer.beforeInit(viewController: vc)
@@ -92,7 +92,7 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
 
         observer.beforeInit(viewController: vc)
@@ -126,7 +126,7 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
 
         observer.beforeInit(viewController: vc)
@@ -154,10 +154,10 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
 
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(200))
@@ -187,12 +187,12 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
         waitForTheNextRunLoop()
 
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
-        TTIObserver.clearCustomCreationTime()
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.clearCustomCreationTime()
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(200))
@@ -225,7 +225,7 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
         waitForTheNextRunLoop()
 
@@ -260,11 +260,11 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
         waitForTheNextRunLoop()
 
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(150))
@@ -289,7 +289,7 @@ class TTIObserverTests: XCTestCase {
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(30))
 
 
-        let observer2 = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer2 = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc2 = UIViewController()
         waitForTheNextRunLoop()
 
@@ -321,13 +321,13 @@ class TTIObserverTests: XCTestCase {
 
         let metricsReceiver = TTIMetricsReceiverStub()
 
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
 
-        TTIObserver.clearCustomCreationTime()
+        TTIObserverHelper.clearCustomCreationTime()
 
         XCTAssertNil(metricsReceiver.ttiMetrics)
 
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
         waitForTheNextRunLoop()
 
@@ -361,11 +361,11 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer1 = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc1 = UIViewController()
+        let observer1 = TTIObserver(screen: vc1, metricsReceiver: metricsReceiver, timeProvider: timeProvider)
 
-        let observer2 = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc2 = UIViewController()
+        let observer2 = TTIObserver(screen: vc2, metricsReceiver: metricsReceiver, timeProvider: timeProvider)
 
         timeProvider.time = time.advanced(by: .milliseconds(500))
         observer1.beforeInit(viewController: vc1)
@@ -380,7 +380,7 @@ class TTIObserverTests: XCTestCase {
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(1300))
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(1400))
@@ -395,7 +395,7 @@ class TTIObserverTests: XCTestCase {
 
         XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(400))  // between 500 and 900
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(100))  // between 500 and 600
-        XCTAssert(metricsReceiver.lastController === vc1)
+        XCTAssertEqual(metricsReceiver.lastController, vc1)
 
         timeProvider.time = time.advanced(by: .milliseconds(1600))
         observer2.afterViewWillAppear(viewController: vc2)
@@ -413,7 +413,7 @@ class TTIObserverTests: XCTestCase {
 
         XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(700))  // between 1300 and 2000
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(200))  // between 1400 and 1600
-        XCTAssert(metricsReceiver.lastController === vc2)
+        XCTAssertEqual(metricsReceiver.lastController, vc2)
     }
 
     func testCustomCreationAfterViewWillAppear() {
@@ -424,7 +424,7 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc = UIViewController()
         waitForTheNextRunLoop()
 
@@ -437,7 +437,7 @@ class TTIObserverTests: XCTestCase {
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(600))
-        TTIObserver.startCustomCreationTime(timeProvider: timeProvider)
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
         waitForTheNextRunLoop()
 
         timeProvider.time = time.advanced(by: .milliseconds(900))
@@ -454,7 +454,7 @@ class TTIObserverTests: XCTestCase {
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(300))  // between 100 and 400
 
         // prepare for the next test
-        TTIObserver.clearCustomCreationTime()
+        TTIObserverHelper.clearCustomCreationTime()
         waitForTheNextRunLoop()
     }
 
@@ -465,11 +465,11 @@ class TTIObserverTests: XCTestCase {
         let time = timeProvider.time
 
         let metricsReceiver = TTIMetricsReceiverStub()
-        let observer1 = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc1 = UIViewController()
+        let observer1 = TTIObserver(screen: vc1, metricsReceiver: metricsReceiver, timeProvider: timeProvider)
 
-        let observer2 = TTIObserver(metricsReceiver: metricsReceiver, timeProvider: timeProvider)
         let vc2 = UIViewController()
+        let observer2 = TTIObserver(screen: vc2, metricsReceiver: metricsReceiver, timeProvider: timeProvider)
 
         timeProvider.time = time.advanced(by: .milliseconds(500))
         observer1.beforeInit(viewController: vc1)
@@ -497,7 +497,7 @@ class TTIObserverTests: XCTestCase {
 
         XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(800))  // between 500 and 1300
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(100))  // between 500 and 600
-        XCTAssert(metricsReceiver.lastController === vc2)
+        XCTAssertEqual(metricsReceiver.lastController, vc2)
 
         metricsReceiver.lastController = nil
         metricsReceiver.ttiMetrics = nil
@@ -531,18 +531,18 @@ class TimeProviderStub: TimeProvider {
 }
 
 class TTIMetricsReceiverStub: TTIMetricsReceiver {
-    func ttiMetricsReceived(metrics: TTIMetrics, viewController: UIViewController) {
+    func ttiMetricsReceived(metrics: TTIMetrics, screen viewController: UIViewController) {
         ttiCallback(metrics, viewController)
         ttiMetrics = metrics
         lastController = viewController
     }
 
-    func shouldTrack(viewController: UIViewController) -> Bool {
+    func screenIdentifier(for viewController: UIViewController) -> UIViewController? {
         if viewController is UINavigationController
             || viewController is UITabBarController {
-            return false
+            return nil
         }
-        return true
+        return viewController
     }
 
     var ttiCallback: (TTIMetrics, UIViewController) -> Void = { (_, _) in }

--- a/PerformanceSuite/Tests/ViewControllerObserverTests.swift
+++ b/PerformanceSuite/Tests/ViewControllerObserverTests.swift
@@ -73,7 +73,7 @@ class ViewControllerObserverTests: XCTestCase {
     }
 
     func testObserversFactory() {
-        let factory = ViewControllerObserverFactory<Observer>(metricsReceiver: TTIMetricsReceiverStub()) {
+        let factory = ViewControllerObserverFactory<Observer, TTIMetricsReceiverStub>(metricsReceiver: TTIMetricsReceiverStub()) { screen in
             Observer()
         }
 
@@ -126,7 +126,7 @@ class ViewControllerObserverTests: XCTestCase {
 
     func testSwiftUIHostingControllerIsIgnored() {
         let metricsReceiver = MetricsConsumerForSwiftUITest()
-        let factory = ViewControllerObserverFactory<Observer>(metricsReceiver: metricsReceiver) {
+        let factory = ViewControllerObserverFactory<Observer, MetricsConsumerForSwiftUITest>(metricsReceiver: metricsReceiver) { screen in
             Observer()
         }
 
@@ -143,7 +143,7 @@ class ViewControllerObserverTests: XCTestCase {
 }
 
 private class MetricsConsumerForSwiftUITest: ScreenMetricsReceiver {
-    func ttiMetricsReceived(metrics: TTIMetrics, viewController: UIViewController) {}
-    func renderingMetricsReceived(metrics: RenderingMetrics, viewController: UIViewController) {}
+    func ttiMetricsReceived(metrics: TTIMetrics, screen: UIViewController) {}
+    func renderingMetricsReceived(metrics: RenderingMetrics, screen: UIViewController) {}
     func appRenderingMetricsReceived(metrics: RenderingMetrics) {}
 }

--- a/PerformanceSuite/Tests/ViewControllerSubscriberTests.swift
+++ b/PerformanceSuite/Tests/ViewControllerSubscriberTests.swift
@@ -234,6 +234,8 @@ class Observer: ViewControllerObserver {
         lastTime = DispatchTime.now()
     }
 
+    static let identifier: AnyObject = NSObject()
+
     func clear() {
         viewController = nil
         lastMethod = nil


### PR DESCRIPTION
Currently we pass `UIViewController` to all the methods of screen metrics receivers. This is flexible, but may be not so convenient for the end-users. This is also not performant as we convert view controller to the identifier in the consumer code for every callback.

In the end, in all the apps we will have some sort of identifiers for view controllers, enum, or string. We can make a convenient way to convert view controllers to those identifiers on the main thread just after view controller is created. And later we will forget about UIViewController objects and work with the light-weight identifiers only.