### PR TITLE
Avoid deallocations of the view controllers on background threads

### DIFF
--- a/PerformanceSuite/Tests/TTIObserverExtensionTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverExtensionTests.swift
@@ -19,6 +19,7 @@ class TTIObserverExtensionTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        PerformanceMonitoring.experiments = Experiments(observersOnBackgroundQueue: true)
         defaultTimeProvider = timeProvider
         metricsReceiver = TTIMetricsReceiverStub()
         try PerformanceMonitoring.enable(config: [.screenLevelTTI(metricsReceiver)], experiments: Experiments(observersOnBackgroundQueue: true))
@@ -244,7 +245,8 @@ class TTIObserverExtensionTests: XCTestCase {
         window.rootViewController = tabbar
         window.makeKeyAndVisible()
 
-        waitForExpectations(timeout: 3, handler: nil)
+        wait(for: [exp1], timeout: 3)
+        PerformanceMonitoring.queue.sync {}
 
         // for the first controller we should calculate TTI between `init` and `screenIsReady` -> 1 second
         vc1.screenIsReady()
@@ -334,7 +336,8 @@ class TTIObserverExtensionTests: XCTestCase {
         window.rootViewController = vc1
         window.makeKeyAndVisible()
 
-        waitForExpectations(timeout: 3, handler: nil)
+        wait(for: [exp1], timeout: 3)
+        PerformanceMonitoring.queue.sync {}
 
         // we call screenIsReady for the child, but it should work for the parent
         vc2.screenIsReady()
@@ -402,6 +405,10 @@ private class MyViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         output += "viewDidLayoutSubviews\n"
+    }
+
+    deinit {
+        XCTAssertTrue(Thread.isMainThread)
     }
 }
 

--- a/PerformanceSuite/Tests/ViewControllerObserverTests.swift
+++ b/PerformanceSuite/Tests/ViewControllerObserverTests.swift
@@ -12,6 +12,18 @@ import XCTest
 
 class ViewControllerObserverTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        PerformanceMonitoring.experiments = Experiments(observersOnBackgroundQueue: true)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        PerformanceMonitoring.consumerQueue.sync { }
+        PerformanceMonitoring.queue.sync { }
+        PerformanceMonitoring.experiments = Experiments()
+    }
+
     func testObserversCollection() {
         let o1 = Observer()
         let o2 = Observer()
@@ -159,4 +171,8 @@ private class MetricsConsumerForSwiftUITest: ScreenMetricsReceiver {
     func appRenderingMetricsReceived(metrics: RenderingMetrics) {}
 }
 
-private class MyViewController: UIViewController { }
+private class MyViewController: UIViewController {
+    deinit {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}


### PR DESCRIPTION
If the view controller is deallocated on the background thread, it can cause the data races in UIKit. Trying to avoid that.