### PR TITLE
Improve experiment observersOnBackgroundQueue

### DIFF
--- a/PerformanceSuite/Sources/ViewControllerObserver.swift
+++ b/PerformanceSuite/Sources/ViewControllerObserver.swift
@@ -34,7 +34,7 @@ final class ViewControllerObserverFactory<T: ViewControllerObserver, S: ScreenMe
     private let observerMaker: (S.ScreenIdentifier) -> T
 
     private func ensureDeallocationOnTheMainThread(viewController: UIViewController) {
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [viewController] in
             // Make sure viewController is deallocated on the main thread, because
             // if the last access is on the background thread, it will be deallocated
             // in background, and it can cause data races in UIKit.

--- a/PerformanceSuite/Sources/ViewControllerSubscriber.swift
+++ b/PerformanceSuite/Sources/ViewControllerSubscriber.swift
@@ -22,37 +22,66 @@ final class ViewControllerSubscriber {
     private let viewDidDisappearSelector = #selector(UIViewController.viewDidDisappear(_:))
 
     func subscribeObserver(_ observer: ViewControllerObserver) throws {
-        try Swizzler.swizzle(class: classToSwizzle, selector: initWithNibSelector) { (vc: UIViewController) in
-            observer.beforeInit(viewController: vc)
-        }
+        if PerformanceMonitoring.experiments.observersOnBackgroundQueue {
+            try Swizzler.swizzle(class: classToSwizzle, selector: initWithNibSelector) { (vc: UIViewController) in
+                observer.beforeInit(viewController: vc)
+            }
 
+            try Swizzler.swizzle(class: classToSwizzle, selector: initWithCoderSelector) { (vc: UIViewController) in
+                observer.beforeInit(viewController: vc)
+            }
 
-        try Swizzler.swizzle(class: classToSwizzle, selector: initWithCoderSelector) { (vc: UIViewController) in
-            observer.beforeInit(viewController: vc)
-        }
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidLoadSelector) { (vc: UIViewController) in
+                observer.beforeViewDidLoad(viewController: vc)
+            }
 
-        try Swizzler.swizzle(class: classToSwizzle, selector: viewDidLoadSelector) { (vc: UIViewController) in
-            observer.beforeViewDidLoad(viewController: vc)
-        }
-
-        try Swizzler.swizzle(class: classToSwizzle, selector: viewWillAppearSelector) { (vc: UIViewController) in
-            DispatchQueue.main.async {
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewWillAppearSelector, after: true) { (vc: UIViewController) in
                 observer.afterViewWillAppear(viewController: vc)
             }
-        }
 
-        try Swizzler.swizzle(class: classToSwizzle, selector: viewDidAppearSelector) { (vc: UIViewController) in
-            DispatchQueue.main.async {
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidAppearSelector, after: true) { (vc: UIViewController) in
                 observer.afterViewDidAppear(viewController: vc)
             }
-        }
 
-        try Swizzler.swizzle(class: classToSwizzle, selector: viewWillDisappearSelector) { (vc: UIViewController) in
-            observer.beforeViewWillDisappear(viewController: vc)
-        }
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewWillDisappearSelector) { (vc: UIViewController) in
+                observer.beforeViewWillDisappear(viewController: vc)
+            }
 
-        try Swizzler.swizzle(class: classToSwizzle, selector: viewDidDisappearSelector) { (vc: UIViewController) in
-            observer.beforeViewDidDisappear(viewController: vc)
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidDisappearSelector) { (vc: UIViewController) in
+                observer.beforeViewDidDisappear(viewController: vc)
+            }
+        } else {
+            try Swizzler.swizzle(class: classToSwizzle, selector: initWithNibSelector) { (vc: UIViewController) in
+                observer.beforeInit(viewController: vc)
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: initWithCoderSelector) { (vc: UIViewController) in
+                observer.beforeInit(viewController: vc)
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidLoadSelector) { (vc: UIViewController) in
+                observer.beforeViewDidLoad(viewController: vc)
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewWillAppearSelector) { (vc: UIViewController) in
+                DispatchQueue.main.async {
+                    observer.afterViewWillAppear(viewController: vc)
+                }
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidAppearSelector) { (vc: UIViewController) in
+                DispatchQueue.main.async {
+                    observer.afterViewDidAppear(viewController: vc)
+                }
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewWillDisappearSelector) { (vc: UIViewController) in
+                observer.beforeViewWillDisappear(viewController: vc)
+            }
+
+            try Swizzler.swizzle(class: classToSwizzle, selector: viewDidDisappearSelector) { (vc: UIViewController) in
+                observer.beforeViewDidDisappear(viewController: vc)
+            }
         }
     }
 

--- a/PerformanceSuite/Tests/SwizzlerTests.swift
+++ b/PerformanceSuite/Tests/SwizzlerTests.swift
@@ -112,6 +112,40 @@ class SwizzlerTests: XCTestCase {
         try Swizzler.unswizzle(class: C1.self, selector: selector)
     }
 
+    func testSwizzleBeforeWorks() throws {
+        let selector = #selector(C1.testMethod1Param(p1:))
+        var swizzledCalled = false
+        try Swizzler.swizzle(class: C1.self, selector: selector, after: false) { (c1: C1) in
+            XCTAssert(c1.lastP1 as? Bool == nil)
+            swizzledCalled = true
+        }
+
+        let c1 = C1()
+        XCTAssertNil(c1.lastP1)
+        XCTAssertFalse(swizzledCalled)
+        _ = c1.testMethod1Param(p1: true)
+        XCTAssertTrue(swizzledCalled)
+
+        try Swizzler.unswizzle(class: C1.self, selector: selector)
+    }
+
+    func testSwizzleAfterWorks() throws {
+        let selector = #selector(C1.testMethod1Param(p1:))
+        var swizzledCalled = false
+        try Swizzler.swizzle(class: C1.self, selector: selector, after: true) { (c1: C1) in
+            XCTAssert(c1.lastP1 as? Bool == true)
+            swizzledCalled = true
+        }
+
+        let c1 = C1()
+        XCTAssertNil(c1.lastP1)
+        XCTAssertFalse(swizzledCalled)
+        _ = c1.testMethod1Param(p1: true)
+        XCTAssertTrue(swizzledCalled)
+
+        try Swizzler.unswizzle(class: C1.self, selector: selector)
+    }
+
     private var lastCalled: C1?
 }
 


### PR DESCRIPTION
- Do not delay before/after in swizzler, but call it before/after properly
- Do not switch queues in TTIObserver