### PR TITLE
Added ability to disable crashlytics in DEBUG

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: 16.4
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: 16.4
       - name: Checkout
         uses: actions/checkout@v4
       
@@ -59,7 +59,7 @@ jobs:
       - name: Run Unit Tests
         env:
           scheme: UnitTests
-          destination: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
           workspace: Project.xcworkspace
         run: |
           xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData
@@ -94,7 +94,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: 16.4
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
       - name: Run UI Tests
         env:
           scheme: UITests
-          destination: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
           workspace: Project.xcworkspace
         run: |
           xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ on:
       - '*'
 jobs:
   swiftpm-build:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.4
+          xcode-version: 26.0
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -43,12 +43,12 @@ jobs:
           git checkout -- Project.xcodeproj
           git checkout -- Project.xcworkspace
   unit-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.4
+          xcode-version: 26.0
       - name: Checkout
         uses: actions/checkout@v4
       
@@ -59,7 +59,7 @@ jobs:
       - name: Run Unit Tests
         env:
           scheme: UnitTests
-          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |
@@ -101,12 +101,12 @@ jobs:
           path: cobertura.xml
 
   ui-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.4
+          xcode-version: 26.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
       - name: Run UI Tests
         env:
           scheme: UITests
-          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,10 +59,22 @@ jobs:
       - name: Run Unit Tests
         env:
           scheme: UnitTests
-          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6
           workspace: Project.xcworkspace
+        timeout-minutes: 30
         run: |
-          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData
+          set -e
+          echo "Starting unit tests with destination: $destination"
+          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UnitTestResults.xcresult
+          echo "Unit tests completed successfully"
+      
+      - name: Upload Unit Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-test-results
+          path: UnitTestResults.xcresult
+          retention-days: 30
       
       - name: Slather
         env:
@@ -106,10 +118,22 @@ jobs:
       - name: Run UI Tests
         env:
           scheme: UITests
-          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5
+          destination: platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6
           workspace: Project.xcworkspace
+        timeout-minutes: 30
         run: |
-          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination"
+          set -e
+          echo "Starting UI tests with destination: $destination"
+          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -resultBundlePath UITestResults.xcresult
+          echo "UI tests completed successfully"
+      
+      - name: Upload UI Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ui-test-results
+          path: UITestResults.xcresult
+          retention-days: 30
 
   coverage-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 jobs:
   swiftpm-build:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -94,7 +94,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 15.4
+          xcode-version: latest
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/PerformanceSuite/Crashlytics/Sources/PerformanceMonitoring+Crashlytics.swift
+++ b/PerformanceSuite/Crashlytics/Sources/PerformanceMonitoring+Crashlytics.swift
@@ -23,28 +23,40 @@ extension PerformanceMonitoring {
     ///   - hangsReportingMode: Defines which hangs and how we send to Crashlytics
     ///   - storage: Simple key/value storage which we use to store some simple objects, by default `UserDefaults` is used.
     ///   - experiments: Feature flags that can be used to enable/disable some experimentation features inside PerformanceSuite. Is used for A/B testing in production.
+    ///   - crashlyticsEnabledInDebug: If `false`, we won't report anything to Crashlytics if `DEBUG` is true.
     ///   **NB:** *Make sure that `FirebaseApp.configure() is called before calling this method! App will crash otherwise.*`
     public static func enableWithCrashlyticsSupport(
         config: Config = [],
         settings: CrashlyticsHangsSettings,
         storage: Storage = UserDefaults.standard,
-        experiments: Experiments = Experiments()
+        experiments: Experiments = Experiments(),
+        crashlyticsEnabledInDebug: Bool = true,
     ) throws {
-        guard FirebaseApp.allApps?.count ?? 0 > 0 else {
-            fatalError("Firebase is not configured yet. Please call `FirebaseApp.configure()` before calling this method.")
-        }
-
-        let didCrashPreviously = Crashlytics.crashlytics().didCrashDuringPreviousExecution()
-        let wrappedConfig = config.map { c in
-            switch c {
-            case .hangs(let receiver):
-                // wrap hang receiver with Crashlytics wrapper to send hangs to Crashlytics
-                return ConfigItem.hangs(CrashlyticsHangsReceiverWrapper(hangsReceiver: receiver, settings: settings))
-            default:
-                return c
+        #if DEBUG
+        let crashlyticsEnabled = crashlyticsEnabledInDebug
+        #else
+        let crashlyticsEnabled = true
+        #endif
+        
+        if crashlyticsEnabled {
+            guard FirebaseApp.allApps?.count ?? 0 > 0 else {
+                fatalError("Firebase is not configured yet. Please call `FirebaseApp.configure()` before calling this method.")
             }
+            
+            let didCrashPreviously = Crashlytics.crashlytics().didCrashDuringPreviousExecution()
+            let wrappedConfig = config.map { c in
+                switch c {
+                case .hangs(let receiver):
+                    // wrap hang receiver with Crashlytics wrapper to send hangs to Crashlytics
+                    return ConfigItem.hangs(CrashlyticsHangsReceiverWrapper(hangsReceiver: receiver, settings: settings))
+                default:
+                    return c
+                }
+            }
+            
+            try PerformanceMonitoring.enable(config: wrappedConfig, storage: storage, didCrashPreviously: didCrashPreviously, experiments: experiments)
+        } else {
+            try PerformanceMonitoring.enable(config: config, storage: storage, didCrashPreviously: false, experiments: experiments)
         }
-
-        try PerformanceMonitoring.enable(config: wrappedConfig, storage: storage, didCrashPreviously: didCrashPreviously, experiments: experiments)
     }
 }

--- a/PerformanceSuite/Crashlytics/Sources/PerformanceMonitoring+Crashlytics.swift
+++ b/PerformanceSuite/Crashlytics/Sources/PerformanceMonitoring+Crashlytics.swift
@@ -37,12 +37,12 @@ extension PerformanceMonitoring {
         #else
         let crashlyticsEnabled = true
         #endif
-        
+
         if crashlyticsEnabled {
             guard FirebaseApp.allApps?.count ?? 0 > 0 else {
                 fatalError("Firebase is not configured yet. Please call `FirebaseApp.configure()` before calling this method.")
             }
-            
+
             let didCrashPreviously = Crashlytics.crashlytics().didCrashDuringPreviousExecution()
             let wrappedConfig = config.map { c in
                 switch c {
@@ -53,7 +53,7 @@ extension PerformanceMonitoring {
                     return c
                 }
             }
-            
+
             try PerformanceMonitoring.enable(config: wrappedConfig, storage: storage, didCrashPreviously: didCrashPreviously, experiments: experiments)
         } else {
             try PerformanceMonitoring.enable(config: config, storage: storage, didCrashPreviously: false, experiments: experiments)

--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -100,16 +100,16 @@ final class PerformanceMonitoringTests: XCTestCase {
         // cleanup PerformanceSuite
         try PerformanceMonitoring.disable()
     }
-    
+
     func testEnableWithDisabledCrashlytics() async throws {
         let settings = CrashlyticsHangsSettings()
         // it shouldn't crash without crashlytics initialized
         try PerformanceMonitoring.enableWithCrashlyticsSupport(config: .all(receiver: self), settings: settings, crashlyticsEnabledInDebug: false)
-        
+
         let hangReporter = try XCTUnwrap(PerformanceMonitoring.appReporters.compactMap { $0 as? HangReporter }.first)
         // check that hangsReceiver is not wrapped
         XCTAssertTrue(hangReporter.receiver is PerformanceMonitoringTests)
-        
+
         // cleanup PerformanceSuite
         try PerformanceMonitoring.disable()
     }

--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -100,6 +100,19 @@ final class PerformanceMonitoringTests: XCTestCase {
         // cleanup PerformanceSuite
         try PerformanceMonitoring.disable()
     }
+    
+    func testEnableWithDisabledCrashlytics() async throws {
+        let settings = CrashlyticsHangsSettings()
+        // it shouldn't crash without crashlytics initialized
+        try PerformanceMonitoring.enableWithCrashlyticsSupport(config: .all(receiver: self), settings: settings, crashlyticsEnabledInDebug: false)
+        
+        let hangReporter = try XCTUnwrap(PerformanceMonitoring.appReporters.compactMap { $0 as? HangReporter }.first)
+        // check that hangsReceiver is not wrapped
+        XCTAssertTrue(hangReporter.receiver is PerformanceMonitoringTests)
+        
+        // cleanup PerformanceSuite
+        try PerformanceMonitoring.disable()
+    }
 
     private func customHangTypeFormatter(_ fatal: Bool, _ startup: Bool) -> String {
         return "hang_type"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,60 +1,58 @@
 PODS:
-  - FirebaseCore (10.29.0):
-    - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.12)
-    - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.29.0):
-    - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.29.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.29.0):
-    - FirebaseCore (~> 10.5)
-    - FirebaseInstallations (~> 10.0)
-    - FirebaseRemoteConfigInterop (~> 10.23)
-    - FirebaseSessions (~> 10.5)
-    - GoogleDataTransport (~> 9.2)
-    - GoogleUtilities/Environment (~> 7.8)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (~> 2.1)
-  - FirebaseInstallations (10.29.0):
-    - FirebaseCore (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - PromisesObjC (~> 2.1)
-  - FirebaseRemoteConfigInterop (10.29.0)
-  - FirebaseSessions (10.29.0):
-    - FirebaseCore (~> 10.5)
-    - FirebaseCoreExtension (~> 10.0)
-    - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.2)
-    - GoogleUtilities/Environment (~> 7.13)
-    - GoogleUtilities/UserDefaults (~> 7.13)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseCore (11.15.0):
+    - FirebaseCoreInternal (~> 11.15.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreExtension (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+  - FirebaseCoreInternal (11.15.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FirebaseCrashlytics (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+    - FirebaseInstallations (~> 11.0)
+    - FirebaseRemoteConfigInterop (~> 11.0)
+    - FirebaseSessions (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseInstallations (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseRemoteConfigInterop (11.15.0)
+  - FirebaseSessions (11.15.0):
+    - FirebaseCore (~> 11.15.0)
+    - FirebaseCoreExtension (~> 11.15.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
   - GCDWebServer (3.5.4):
     - GCDWebServer/Core (= 3.5.4)
   - GCDWebServer/Core (3.5.4)
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Environment (7.13.3):
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - "GoogleUtilities/NSData+zlib (7.13.3)":
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - nanopb (2.30910.0):
-    - nanopb/decode (= 2.30910.0)
-    - nanopb/encode (= 2.30910.0)
-  - nanopb/decode (2.30910.0)
-  - nanopb/encode (2.30910.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - PerformanceSuite (1.5.1):
     - PerformanceSuite/Core (= 1.5.1)
   - PerformanceSuite/Core (1.5.1)
@@ -72,7 +70,7 @@ PODS:
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
-  - SwiftLint (0.54.0)
+  - SwiftLint (0.61.0)
 
 DEPENDENCIES:
   - PerformanceSuite (from `.`)
@@ -103,22 +101,22 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
-  FirebaseCoreExtension: 705ca5b14bf71d2564a0ddc677df1fc86ffa600f
-  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
-  FirebaseCrashlytics: 34647b41e18de773717fdd348a22206f2f9bc774
-  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
-  FirebaseRemoteConfigInterop: 6efda51fb5e2f15b16585197e26eaa09574e8a4d
-  FirebaseSessions: dbd14adac65ce996228652c1fc3a3f576bdf3ecc
+  FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
+  FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
+  FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
+  FirebaseCrashlytics: e09d0bc19aa54a51e45b8039c836ef73f32c039a
+  FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
+  FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
+  FirebaseSessions: b9a92c1c51bbb81e78fc3142cda6d925d700f8e7
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
-  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PerformanceSuite: 5af141eb9dd7f78d1aed03b784000b1d7e9328f4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
+  SwiftLint: bf6da11a31c6644a0bbb27f4fa15fd9636db00b3
 
 PODFILE CHECKSUM: d4d226a130308d989bd6c0ab47526b07da25ad25
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  PerformanceSuite: a1eaed438593abd84bd1f9c7676300d85792af6c
+  PerformanceSuite: 5af141eb9dd7f78d1aed03b784000b1d7e9328f4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211


### PR DESCRIPTION
Because we are adding Crashlytics in the release build only. Of course we can disable it from the outside, but this will be less convenient