### PR TITLE
Add Multi*Receiver fan-out helpers and primary associated types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run Unit Tests
         env:
           scheme: UnitTests
-          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.0.1
+          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |
@@ -118,7 +118,7 @@ jobs:
       - name: Run UI Tests
         env:
           scheme: UITests
-          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.0.1
+          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |

--- a/PerformanceSuite/Sources/InstanceObservers/LoggingObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/LoggingObserver.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// it is not intended to be used for some business-logic.
 ///
 /// If you execute something heavy, offload it to some other background thread.
-public protocol ViewControllerLoggingReceiver: ScreenMetricsReceiver {
+public protocol ViewControllerLoggingReceiver<ScreenIdentifier>: ScreenMetricsReceiver {
 
     /// Method is called during view controller's initialization
     func onInit(screen: ScreenIdentifier)

--- a/PerformanceSuite/Sources/Public/ConfigItem+Multi.swift
+++ b/PerformanceSuite/Sources/Public/ConfigItem+Multi.swift
@@ -1,0 +1,59 @@
+//
+//  ConfigItem+Multi.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 01/05/2026.
+//
+
+import UIKit
+
+// MARK: - Non-generic receivers (iOS 15+)
+
+extension ConfigItem {
+
+    public static func startupTime(_ receivers: [StartupTimeReceiver]) -> ConfigItem {
+        .startupTime(MultiStartupTimeReceiver(receivers: receivers))
+    }
+
+    public static func hangs(_ receivers: [HangsReceiver]) -> ConfigItem {
+        .hangs(MultiHangsReceiver(receivers: receivers))
+    }
+
+    public static func appLevelRendering(_ receivers: [AppRenderingMetricsReceiver]) -> ConfigItem {
+        .appLevelRendering(MultiAppRenderingMetricsReceiver(receivers: receivers))
+    }
+
+    public static func watchdogTerminations(_ receivers: [WatchdogTerminationsReceiver]) -> ConfigItem {
+        .watchdogTerminations(MultiWatchdogTerminationsReceiver(receivers: receivers))
+    }
+}
+
+// MARK: - Generic receivers (iOS 16+)
+
+@available(iOS 16.0, *)
+extension ConfigItem {
+
+    public static func screenLevelTTI<Screen>(
+        screenIdentifier: @escaping (UIViewController) -> Screen?,
+        receivers: [any TTIMetricsReceiver<Screen>]
+    ) -> ConfigItem {
+        .screenLevelTTI(MultiTTIMetricsReceiver(
+            screenIdentifier: screenIdentifier,
+            receivers: receivers))
+    }
+
+    public static func screenLevelRendering<Screen>(
+        screenIdentifier: @escaping (UIViewController) -> Screen?,
+        receivers: [any RenderingMetricsReceiver<Screen>]
+    ) -> ConfigItem {
+        .screenLevelRendering(MultiRenderingMetricsReceiver(
+            screenIdentifier: screenIdentifier,
+            receivers: receivers))
+    }
+
+    public static func fragmentTTI<Fragment>(
+        _ receivers: [any FragmentTTIMetricsReceiver<Fragment>]
+    ) -> ConfigItem {
+        .fragmentTTI(MultiFragmentTTIMetricsReceiver(receivers: receivers))
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiAppRenderingMetricsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiAppRenderingMetricsReceiver.swift
@@ -1,0 +1,26 @@
+//
+//  MultiAppRenderingMetricsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Composite ``AppRenderingMetricsReceiver`` that fans out every event to every
+/// receiver in the supplied array.
+public final class MultiAppRenderingMetricsReceiver: AppRenderingMetricsReceiver {
+
+    private let receivers: [AppRenderingMetricsReceiver]
+
+    /// - Parameter receivers: The receivers to fan out to. Order is preserved.
+    public init(receivers: [AppRenderingMetricsReceiver]) {
+        self.receivers = receivers
+    }
+
+    public func appRenderingMetricsReceived(metrics: RenderingMetrics) {
+        for receiver in receivers {
+            receiver.appRenderingMetricsReceived(metrics: metrics)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiFragmentTTIMetricsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiFragmentTTIMetricsReceiver.swift
@@ -1,0 +1,34 @@
+//
+//  MultiFragmentTTIMetricsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Composite ``FragmentTTIMetricsReceiver`` that fans out every event to every
+/// receiver in the supplied array. Unlike ``MultiTTIMetricsReceiver`` there is no
+/// view-controller-to-identifier mapping closure here — the fragment identifier is
+/// provided by the caller of ``PerformanceMonitoring/startFragmentTTI(identifier:)``,
+/// so this composite simply forwards what it receives.
+///
+/// - Note: Requires iOS 16 or later. See ``MultiTTIMetricsReceiver`` for the rationale.
+@available(iOS 16.0, *)
+public final class MultiFragmentTTIMetricsReceiver<Fragment>: FragmentTTIMetricsReceiver {
+
+    public typealias FragmentIdentifier = Fragment
+
+    private let receivers: [any FragmentTTIMetricsReceiver<Fragment>]
+
+    /// - Parameter receivers: The receivers to fan out to. Order is preserved.
+    public init(receivers: [any FragmentTTIMetricsReceiver<Fragment>]) {
+        self.receivers = receivers
+    }
+
+    public func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment: Fragment) {
+        for receiver in receivers {
+            receiver.fragmentTTIMetricsReceived(metrics: metrics, fragment: fragment)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiHangsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiHangsReceiver.swift
@@ -1,0 +1,54 @@
+//
+//  MultiHangsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Composite ``HangsReceiver`` that fans out every event to every receiver in the
+/// supplied array.
+///
+/// `hangThreshold` is taken from the first receiver — it is a single value used by
+/// the underlying detection timer at config time, so there is no meaningful "fan
+/// out" for it. Pass the receivers in the order whose `hangThreshold` you want to
+/// win, or pre-align the values across receivers if you depend on the precise
+/// threshold of more than one of them.
+public final class MultiHangsReceiver: HangsReceiver {
+
+    private let receivers: [HangsReceiver]
+    private let _hangThreshold: TimeInterval
+
+    /// - Parameter receivers: The receivers to fan out to. Order is preserved. Must
+    ///   contain at least one element — an empty array would leave
+    ///   ``hangThreshold`` without a sensible value and would silently swallow all
+    ///   hang events.
+    public init(receivers: [HangsReceiver]) {
+        precondition(!receivers.isEmpty, "MultiHangsReceiver requires at least one receiver")
+        self.receivers = receivers
+        self._hangThreshold = receivers[0].hangThreshold
+    }
+
+    public var hangThreshold: TimeInterval {
+        _hangThreshold
+    }
+
+    public func fatalHangReceived(info: HangInfo) {
+        for receiver in receivers {
+            receiver.fatalHangReceived(info: info)
+        }
+    }
+
+    public func nonFatalHangReceived(info: HangInfo) {
+        for receiver in receivers {
+            receiver.nonFatalHangReceived(info: info)
+        }
+    }
+
+    public func hangStarted(info: HangInfo) {
+        for receiver in receivers {
+            receiver.hangStarted(info: info)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiRenderingMetricsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiRenderingMetricsReceiver.swift
@@ -1,0 +1,44 @@
+//
+//  MultiRenderingMetricsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import UIKit
+
+/// Composite ``RenderingMetricsReceiver`` that fans out every event to every receiver
+/// in the supplied array. See ``MultiTTIMetricsReceiver`` for design notes that apply
+/// equally here.
+///
+/// - Note: Requires iOS 16 or later. See ``MultiTTIMetricsReceiver`` for the rationale.
+@available(iOS 16.0, *)
+public final class MultiRenderingMetricsReceiver<Screen>: RenderingMetricsReceiver {
+
+    public typealias ScreenIdentifier = Screen
+
+    private let _screenIdentifier: (UIViewController) -> Screen?
+    private let receivers: [any RenderingMetricsReceiver<Screen>]
+
+    /// - Parameters:
+    ///   - screenIdentifier: Closure that maps `UIViewController` instances to ``Screen``.
+    ///     See ``MultiTTIMetricsReceiver/init(screenIdentifier:receivers:)`` for the contract.
+    ///   - receivers: The receivers to fan out to. Order is preserved.
+    public init(
+        screenIdentifier: @escaping (UIViewController) -> Screen?,
+        receivers: [any RenderingMetricsReceiver<Screen>]
+    ) {
+        self._screenIdentifier = screenIdentifier
+        self.receivers = receivers
+    }
+
+    public func screenIdentifier(for viewController: UIViewController) -> Screen? {
+        _screenIdentifier(viewController)
+    }
+
+    public func renderingMetricsReceived(metrics: RenderingMetrics, screen: Screen) {
+        for receiver in receivers {
+            receiver.renderingMetricsReceived(metrics: metrics, screen: screen)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiStartupTimeReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiStartupTimeReceiver.swift
@@ -1,0 +1,26 @@
+//
+//  MultiStartupTimeReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Composite ``StartupTimeReceiver`` that fans out every event to every receiver
+/// in the supplied array.
+public final class MultiStartupTimeReceiver: StartupTimeReceiver {
+
+    private let receivers: [StartupTimeReceiver]
+
+    /// - Parameter receivers: The receivers to fan out to. Order is preserved.
+    public init(receivers: [StartupTimeReceiver]) {
+        self.receivers = receivers
+    }
+
+    public func startupTimeReceived(_ data: StartupTimeData) {
+        for receiver in receivers {
+            receiver.startupTimeReceived(data)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiTTIMetricsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiTTIMetricsReceiver.swift
@@ -1,0 +1,57 @@
+//
+//  MultiTTIMetricsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import UIKit
+
+/// Composite ``TTIMetricsReceiver`` that fans out every event to every receiver in the
+/// supplied array. Useful when the same TTI signal must reach multiple consumers
+/// (e.g. an analytics receiver and a separate OpenTelemetry receiver) without having
+/// to duplicate the dispatch logic in each reporter.
+///
+/// `screenIdentifier(for:)` is provided as a separate closure rather than delegated
+/// to one of the wrapped receivers — this avoids ambiguity about whose mapping wins
+/// when the receivers disagree, and lets callers reuse a single screen-identifier
+/// implementation across multiple ``Multi``*Receiver instances.
+///
+/// - Note: Requires iOS 16 or later because the heterogeneous receiver array uses
+///   constrained existential types (`any TTIMetricsReceiver<Screen>`), whose runtime
+///   support shipped with iOS 16. iOS 15 consumers of `PerformanceSuite` that need
+///   to combine receivers must implement their own composition.
+@available(iOS 16.0, *)
+public final class MultiTTIMetricsReceiver<Screen>: TTIMetricsReceiver {
+
+    public typealias ScreenIdentifier = Screen
+
+    private let _screenIdentifier: (UIViewController) -> Screen?
+    private let receivers: [any TTIMetricsReceiver<Screen>]
+
+    /// - Parameters:
+    ///   - screenIdentifier: Closure that maps `UIViewController` instances to ``Screen``.
+    ///     Mirrors the contract of ``ScreenMetricsReceiver/screenIdentifier(for:)``: return
+    ///     `nil` for view controllers that should not be tracked. Must be fast — it is
+    ///     invoked on the internal performance queue during `init` of every observed
+    ///     view controller.
+    ///   - receivers: The receivers to fan out to. Order is preserved; each receiver
+    ///     is invoked synchronously on the consumer queue in the order supplied.
+    public init(
+        screenIdentifier: @escaping (UIViewController) -> Screen?,
+        receivers: [any TTIMetricsReceiver<Screen>]
+    ) {
+        self._screenIdentifier = screenIdentifier
+        self.receivers = receivers
+    }
+
+    public func screenIdentifier(for viewController: UIViewController) -> Screen? {
+        _screenIdentifier(viewController)
+    }
+
+    public func ttiMetricsReceived(metrics: TTIMetrics, screen: Screen) {
+        for receiver in receivers {
+            receiver.ttiMetricsReceived(metrics: metrics, screen: screen)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/MultiWatchdogTerminationsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/MultiWatchdogTerminationsReceiver.swift
@@ -1,0 +1,26 @@
+//
+//  MultiWatchdogTerminationsReceiver.swift
+//  PerformanceSuite
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Composite ``WatchdogTerminationsReceiver`` that fans out every event to every
+/// receiver in the supplied array.
+public final class MultiWatchdogTerminationsReceiver: WatchdogTerminationsReceiver {
+
+    private let receivers: [WatchdogTerminationsReceiver]
+
+    /// - Parameter receivers: The receivers to fan out to. Order is preserved.
+    public init(receivers: [WatchdogTerminationsReceiver]) {
+        self.receivers = receivers
+    }
+
+    public func watchdogTerminationReceived(_ data: WatchdogTerminationData) {
+        for receiver in receivers {
+            receiver.watchdogTerminationReceived(data)
+        }
+    }
+}

--- a/PerformanceSuite/Sources/Public/ScreenMetricsReceiver.swift
+++ b/PerformanceSuite/Sources/Public/ScreenMetricsReceiver.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /// Base protocol for screen-level TTI and Rendering receivers
-public protocol ScreenMetricsReceiver: AnyObject {
+public protocol ScreenMetricsReceiver<ScreenIdentifier>: AnyObject {
     /// ScreenIdentifier can be String, some enum, or UIViewController itself.
     associatedtype ScreenIdentifier
 
@@ -42,7 +42,7 @@ public extension ScreenMetricsReceiver where ScreenIdentifier == UIViewControlle
 /// You should implement this protocol to receive TTI metrics in your code.
 ///
 /// Pass instance of this protocol to the config item `ConfigItem.screenLevelTTI`
-public protocol TTIMetricsReceiver: ScreenMetricsReceiver {
+public protocol TTIMetricsReceiver<ScreenIdentifier>: ScreenMetricsReceiver {
     /// Method is called when TTI metrics are calculated for some screen.
     ///
     /// `Config.screenLevelTTI` should be enabled.
@@ -61,7 +61,7 @@ public protocol TTIMetricsReceiver: ScreenMetricsReceiver {
 /// You should implement this protocol to receive screen-level rendering metrics in your code.
 ///
 /// Pass instance of this protocol to the config item `ConfigItem.screenLevelRendering`
-public protocol RenderingMetricsReceiver: ScreenMetricsReceiver {
+public protocol RenderingMetricsReceiver<ScreenIdentifier>: ScreenMetricsReceiver {
     /// Method is called when performance metrics are calculated for some screen.
     ///
     /// `Config.screenLevelRendering` should be enabled.

--- a/PerformanceSuite/Sources/Reporters/FragmentTTIReporter.swift
+++ b/PerformanceSuite/Sources/Reporters/FragmentTTIReporter.swift
@@ -23,7 +23,7 @@ public protocol FragmentTTITrackable: AnyObject {
 
 
 /// Implement this protocol if you want to receive events about Fragment TTI
-public protocol FragmentTTIMetricsReceiver: AnyObject {
+public protocol FragmentTTIMetricsReceiver<FragmentIdentifier>: AnyObject {
     /// This can be String, or enum or any other identifier
     associatedtype FragmentIdentifier
 

--- a/PerformanceSuite/Tests/MultiAppRenderingMetricsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiAppRenderingMetricsReceiverTests.swift
@@ -1,0 +1,73 @@
+//
+//  MultiAppRenderingMetricsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+final class MultiAppRenderingMetricsReceiverTests: XCTestCase {
+
+    private final class AppRenderingStub: AppRenderingMetricsReceiver {
+        var received: [RenderingMetrics] = []
+        func appRenderingMetricsReceived(metrics: RenderingMetrics) {
+            received.append(metrics)
+        }
+    }
+
+    private func makeMetrics() -> RenderingMetrics {
+        RenderingMetrics(
+            renderedFrames: 240,
+            expectedFrames: 240,
+            droppedFrames: 0,
+            frozenFrames: 0,
+            slowFrames: 0,
+            freezeTime: .milliseconds(0),
+            sessionDuration: .seconds(4),
+            appStartInfo: .empty
+        )
+    }
+
+    func testFanOutToAllReceivers() {
+        let first = AppRenderingStub()
+        let second = AppRenderingStub()
+        let third = AppRenderingStub()
+        let multi = MultiAppRenderingMetricsReceiver(receivers: [first, second, third])
+
+        let metrics = makeMetrics()
+        multi.appRenderingMetricsReceived(metrics: metrics)
+
+        XCTAssertEqual(first.received, [metrics])
+        XCTAssertEqual(second.received, [metrics])
+        XCTAssertEqual(third.received, [metrics])
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiAppRenderingMetricsReceiver(receivers: [])
+        multi.appRenderingMetricsReceived(metrics: makeMetrics())
+    }
+
+    func testOrderPreserved() {
+        var order: [Int] = []
+        final class OrderingStub: AppRenderingMetricsReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func appRenderingMetricsReceived(metrics: RenderingMetrics) {
+                onCall(id)
+            }
+        }
+        let multi = MultiAppRenderingMetricsReceiver(receivers: [
+            OrderingStub(id: 1, onCall: { order.append($0) }),
+            OrderingStub(id: 2, onCall: { order.append($0) }),
+        ])
+        multi.appRenderingMetricsReceived(metrics: makeMetrics())
+
+        XCTAssertEqual(order, [1, 2])
+    }
+}

--- a/PerformanceSuite/Tests/MultiFragmentTTIMetricsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiFragmentTTIMetricsReceiverTests.swift
@@ -1,0 +1,68 @@
+//
+//  MultiFragmentTTIMetricsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+@available(iOS 16.0, *)
+final class MultiFragmentTTIMetricsReceiverTests: XCTestCase {
+
+    // FragmentIdentifier is inferred from the method signature below.
+    private final class StringFragmentReceiverStub: FragmentTTIMetricsReceiver {
+        var received: [(TTIMetrics, String)] = []
+        func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment: String) {
+            received.append((metrics, fragment))
+        }
+    }
+
+    func testFanOutToAllReceivers() {
+        let first = StringFragmentReceiverStub()
+        let second = StringFragmentReceiverStub()
+        let multi = MultiFragmentTTIMetricsReceiver<String>(receivers: [first, second])
+
+        let metrics = TTIMetrics(tti: .milliseconds(75), ttfr: .milliseconds(10), appStartInfo: .empty)
+        multi.fragmentTTIMetricsReceived(metrics: metrics, fragment: "search_filter_panel")
+
+        XCTAssertEqual(first.received.count, 1)
+        XCTAssertEqual(first.received.first?.1, "search_filter_panel")
+        XCTAssertEqual(first.received.first?.0, metrics)
+        XCTAssertEqual(second.received.count, 1)
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiFragmentTTIMetricsReceiver<String>(receivers: [])
+        let metrics = TTIMetrics(tti: .milliseconds(1), ttfr: .milliseconds(1), appStartInfo: .empty)
+        multi.fragmentTTIMetricsReceived(metrics: metrics, fragment: "x")
+    }
+
+    func testOrderPreserved() {
+        var order: [Int] = []
+        final class OrderingStub: FragmentTTIMetricsReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment: String) {
+                onCall(id)
+            }
+        }
+        let receivers: [any FragmentTTIMetricsReceiver<String>] = [
+            OrderingStub(id: 7, onCall: { order.append($0) }),
+            OrderingStub(id: 8, onCall: { order.append($0) }),
+            OrderingStub(id: 9, onCall: { order.append($0) }),
+        ]
+        let multi = MultiFragmentTTIMetricsReceiver<String>(receivers: receivers)
+        multi.fragmentTTIMetricsReceived(
+            metrics: TTIMetrics(tti: .milliseconds(1), ttfr: .milliseconds(1), appStartInfo: .empty),
+            fragment: "f"
+        )
+
+        XCTAssertEqual(order, [7, 8, 9])
+    }
+}

--- a/PerformanceSuite/Tests/MultiHangsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiHangsReceiverTests.swift
@@ -1,0 +1,123 @@
+//
+//  MultiHangsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+final class MultiHangsReceiverTests: XCTestCase {
+
+    private final class HangStub: HangsReceiver {
+        var fatal: [HangInfo] = []
+        var nonFatal: [HangInfo] = []
+        var started: [HangInfo] = []
+        var customThreshold: TimeInterval = 2
+
+        func fatalHangReceived(info: HangInfo) {
+            fatal.append(info)
+        }
+        func nonFatalHangReceived(info: HangInfo) {
+            nonFatal.append(info)
+        }
+        func hangStarted(info: HangInfo) {
+            started.append(info)
+        }
+        var hangThreshold: TimeInterval {
+            customThreshold
+        }
+    }
+
+    func testFanOutFatalNonFatalAndStarted() {
+        let first = HangStub()
+        let second = HangStub()
+        let multi = MultiHangsReceiver(receivers: [first, second])
+
+        let info = HangInfo.with(callStack: "stack", duringStartup: false, duration: .milliseconds(2500))
+        multi.hangStarted(info: info)
+        multi.nonFatalHangReceived(info: info)
+        multi.fatalHangReceived(info: info)
+
+        XCTAssertEqual(first.started.count, 1)
+        XCTAssertEqual(second.started.count, 1)
+        XCTAssertEqual(first.nonFatal.count, 1)
+        XCTAssertEqual(second.nonFatal.count, 1)
+        XCTAssertEqual(first.fatal.count, 1)
+        XCTAssertEqual(second.fatal.count, 1)
+    }
+
+    func testHangThresholdTakenFromFirstReceiver() {
+        let first = HangStub()
+        first.customThreshold = 5
+        let second = HangStub()
+        second.customThreshold = 99
+
+        let multi = MultiHangsReceiver(receivers: [first, second])
+
+        XCTAssertEqual(multi.hangThreshold, 5)
+    }
+
+    func testHangThresholdIsStableAcrossReceiverThresholdChanges() {
+        // The threshold is a config-time value: it's read once at init and used by
+        // the detection timer for the lifetime of the reporter. We must not look it
+        // up dynamically from the first receiver, otherwise a change after init
+        // would silently change behaviour.
+        let first = HangStub()
+        first.customThreshold = 3
+        let multi = MultiHangsReceiver(receivers: [first])
+        XCTAssertEqual(multi.hangThreshold, 3)
+
+        first.customThreshold = 60
+        XCTAssertEqual(multi.hangThreshold, 3, "Threshold must be captured at init, not re-read")
+    }
+
+    func testOrderPreservedForAllMethods() {
+        var startedOrder: [Int] = []
+        var nonFatalOrder: [Int] = []
+        var fatalOrder: [Int] = []
+
+        final class OrderingStub: HangsReceiver {
+            let id: Int
+            let onStarted: (Int) -> Void
+            let onNonFatal: (Int) -> Void
+            let onFatal: (Int) -> Void
+            init(id: Int,
+                 onStarted: @escaping (Int) -> Void,
+                 onNonFatal: @escaping (Int) -> Void,
+                 onFatal: @escaping (Int) -> Void) {
+                self.id = id
+                self.onStarted = onStarted
+                self.onNonFatal = onNonFatal
+                self.onFatal = onFatal
+            }
+            func hangStarted(info: HangInfo) { onStarted(id) }
+            func nonFatalHangReceived(info: HangInfo) { onNonFatal(id) }
+            func fatalHangReceived(info: HangInfo) { onFatal(id) }
+        }
+
+        let multi = MultiHangsReceiver(receivers: [
+            OrderingStub(
+                id: 1,
+                onStarted: { startedOrder.append($0) },
+                onNonFatal: { nonFatalOrder.append($0) },
+                onFatal: { fatalOrder.append($0) }
+            ),
+            OrderingStub(
+                id: 2,
+                onStarted: { startedOrder.append($0) },
+                onNonFatal: { nonFatalOrder.append($0) },
+                onFatal: { fatalOrder.append($0) }
+            ),
+        ])
+        let info = HangInfo.with(callStack: "stack", duringStartup: true, duration: .seconds(3))
+        multi.hangStarted(info: info)
+        multi.nonFatalHangReceived(info: info)
+        multi.fatalHangReceived(info: info)
+
+        XCTAssertEqual(startedOrder, [1, 2])
+        XCTAssertEqual(nonFatalOrder, [1, 2])
+        XCTAssertEqual(fatalOrder, [1, 2])
+    }
+}

--- a/PerformanceSuite/Tests/MultiRenderingMetricsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiRenderingMetricsReceiverTests.swift
@@ -1,0 +1,100 @@
+//
+//  MultiRenderingMetricsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+@available(iOS 16.0, *)
+final class MultiRenderingMetricsReceiverTests: XCTestCase {
+
+    // ScreenIdentifier is inferred from the method signatures below.
+    private final class StringRenderingReceiverStub: RenderingMetricsReceiver {
+        func screenIdentifier(for viewController: UIViewController) -> String? {
+            "should-not-be-called"
+        }
+
+        var received: [(RenderingMetrics, String)] = []
+        func renderingMetricsReceived(metrics: RenderingMetrics, screen: String) {
+            received.append((metrics, screen))
+        }
+    }
+
+    private func makeMetrics() -> RenderingMetrics {
+        RenderingMetrics(
+            renderedFrames: 100,
+            expectedFrames: 100,
+            droppedFrames: 0,
+            frozenFrames: 0,
+            slowFrames: 0,
+            freezeTime: .milliseconds(0),
+            sessionDuration: .seconds(2),
+            appStartInfo: .empty
+        )
+    }
+
+    func testFanOutToAllReceivers() {
+        let first = StringRenderingReceiverStub()
+        let second = StringRenderingReceiverStub()
+        let multi = MultiRenderingMetricsReceiver<String>(
+            screenIdentifier: { _ in "home" },
+            receivers: [first, second]
+        )
+
+        let metrics = makeMetrics()
+        multi.renderingMetricsReceived(metrics: metrics, screen: "home")
+
+        XCTAssertEqual(first.received.count, 1)
+        XCTAssertEqual(second.received.count, 1)
+        XCTAssertEqual(first.received.first?.1, "home")
+        XCTAssertEqual(first.received.first?.0, metrics)
+    }
+
+    func testScreenIdentifierUsesClosure() {
+        let receiver = StringRenderingReceiverStub()
+        let multi = MultiRenderingMetricsReceiver<String>(
+            screenIdentifier: { _ in "screen_from_closure" },
+            receivers: [receiver]
+        )
+
+        XCTAssertEqual(multi.screenIdentifier(for: UIViewController()), "screen_from_closure")
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiRenderingMetricsReceiver<String>(
+            screenIdentifier: { _ in nil },
+            receivers: []
+        )
+        multi.renderingMetricsReceived(metrics: makeMetrics(), screen: "x")
+    }
+
+    func testOrderPreserved() {
+        var order: [Int] = []
+        final class OrderingStub: RenderingMetricsReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func screenIdentifier(for viewController: UIViewController) -> String? { nil }
+            func renderingMetricsReceived(metrics: RenderingMetrics, screen: String) {
+                onCall(id)
+            }
+        }
+        let receivers: [any RenderingMetricsReceiver<String>] = [
+            OrderingStub(id: 5, onCall: { order.append($0) }),
+            OrderingStub(id: 6, onCall: { order.append($0) }),
+        ]
+        let multi = MultiRenderingMetricsReceiver<String>(
+            screenIdentifier: { _ in nil },
+            receivers: receivers
+        )
+        multi.renderingMetricsReceived(metrics: makeMetrics(), screen: "y")
+
+        XCTAssertEqual(order, [5, 6])
+    }
+}

--- a/PerformanceSuite/Tests/MultiStartupTimeReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiStartupTimeReceiverTests.swift
@@ -1,0 +1,82 @@
+//
+//  MultiStartupTimeReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+final class MultiStartupTimeReceiverTests: XCTestCase {
+
+    private final class StartupStub: StartupTimeReceiver {
+        var received: [StartupTimeData] = []
+        func startupTimeReceived(_ data: StartupTimeData) {
+            received.append(data)
+        }
+    }
+
+    private func makeData(prewarmed: Bool = false) -> StartupTimeData {
+        StartupTimeData(
+            totalTime: .milliseconds(1500),
+            preMainTime: .milliseconds(300),
+            mainTime: .milliseconds(1200),
+            totalBeforeViewControllerTime: .milliseconds(900),
+            mainBeforeViewControllerTime: .milliseconds(600),
+            appStartInfo: AppStartInfo(appStartedWithPrewarming: prewarmed)
+        )
+    }
+
+    func testFanOutToAllReceivers() {
+        let first = StartupStub()
+        let second = StartupStub()
+        let multi = MultiStartupTimeReceiver(receivers: [first, second])
+
+        let data = makeData()
+        multi.startupTimeReceived(data)
+
+        XCTAssertEqual(first.received.count, 1)
+        XCTAssertEqual(second.received.count, 1)
+        XCTAssertEqual(first.received.first?.totalTime, data.totalTime)
+        XCTAssertEqual(second.received.first?.totalTime, data.totalTime)
+    }
+
+    func testPrewarmFlagPropagated() {
+        let stub = StartupStub()
+        let multi = MultiStartupTimeReceiver(receivers: [stub])
+
+        multi.startupTimeReceived(makeData(prewarmed: true))
+
+        XCTAssertEqual(stub.received.count, 1)
+        XCTAssertTrue(stub.received.first?.appStartInfo.appStartedWithPrewarming == true)
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiStartupTimeReceiver(receivers: [])
+        multi.startupTimeReceived(makeData())
+    }
+
+    func testOrderPreserved() {
+        var order: [Int] = []
+        final class OrderingStub: StartupTimeReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func startupTimeReceived(_ data: StartupTimeData) {
+                onCall(id)
+            }
+        }
+        let multi = MultiStartupTimeReceiver(receivers: [
+            OrderingStub(id: 10, onCall: { order.append($0) }),
+            OrderingStub(id: 11, onCall: { order.append($0) }),
+            OrderingStub(id: 12, onCall: { order.append($0) }),
+        ])
+        multi.startupTimeReceived(makeData())
+
+        XCTAssertEqual(order, [10, 11, 12])
+    }
+}

--- a/PerformanceSuite/Tests/MultiTTIMetricsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiTTIMetricsReceiverTests.swift
@@ -1,0 +1,110 @@
+//
+//  MultiTTIMetricsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import XCTest
+@testable import PerformanceSuite
+
+@available(iOS 16.0, *)
+final class MultiTTIMetricsReceiverTests: XCTestCase {
+
+    // ScreenIdentifier is inferred from the method signatures below; declaring it
+    // explicitly would push this stub to nesting depth 2 and trip SwiftLint.
+    private final class StringTTIReceiverStub: TTIMetricsReceiver {
+        // We intentionally do not use this: MultiTTIMetricsReceiver overrides screenIdentifier(for:)
+        // with the closure passed to its initializer.
+        func screenIdentifier(for viewController: UIViewController) -> String? {
+            "should-not-be-called"
+        }
+
+        var received: [(TTIMetrics, String)] = []
+        func ttiMetricsReceived(metrics: TTIMetrics, screen: String) {
+            received.append((metrics, screen))
+        }
+    }
+
+    func testFanOutToAllReceiversInOrder() {
+        let first = StringTTIReceiverStub()
+        let second = StringTTIReceiverStub()
+        let third = StringTTIReceiverStub()
+        let invocationOrder = NSMutableArray()
+        first.received = []
+        let multi = MultiTTIMetricsReceiver<String>(
+            screenIdentifier: { _ in "screen_a" },
+            receivers: [first, second, third]
+        )
+
+        let metrics = TTIMetrics(tti: .milliseconds(100), ttfr: .milliseconds(20), appStartInfo: .empty)
+        multi.ttiMetricsReceived(metrics: metrics, screen: "screen_a")
+
+        XCTAssertEqual(first.received.count, 1)
+        XCTAssertEqual(first.received.first?.1, "screen_a")
+        XCTAssertEqual(first.received.first?.0, metrics)
+        XCTAssertEqual(second.received.count, 1)
+        XCTAssertEqual(third.received.count, 1)
+        XCTAssertNotNil(invocationOrder)
+    }
+
+    func testScreenIdentifierUsesClosureNotReceivers() {
+        let receiver = StringTTIReceiverStub()
+        let vc = UIViewController()
+        var capturedVC: UIViewController?
+        let multi = MultiTTIMetricsReceiver<String>(
+            screenIdentifier: { vc in
+                capturedVC = vc
+                return "screen_from_closure"
+            },
+            receivers: [receiver]
+        )
+
+        let result = multi.screenIdentifier(for: vc)
+
+        XCTAssertEqual(result, "screen_from_closure")
+        XCTAssertTrue(capturedVC === vc)
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiTTIMetricsReceiver<String>(
+            screenIdentifier: { _ in nil },
+            receivers: []
+        )
+        let metrics = TTIMetrics(tti: .milliseconds(50), ttfr: .milliseconds(10), appStartInfo: .empty)
+        multi.ttiMetricsReceived(metrics: metrics, screen: "anything")
+    }
+
+    func testReceiversCalledInProvidedOrder() {
+        var order: [Int] = []
+
+        final class OrderingStub: TTIMetricsReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func screenIdentifier(for viewController: UIViewController) -> String? { nil }
+            func ttiMetricsReceived(metrics: TTIMetrics, screen: String) {
+                onCall(id)
+            }
+        }
+
+        let receivers: [any TTIMetricsReceiver<String>] = [
+            OrderingStub(id: 1, onCall: { order.append($0) }),
+            OrderingStub(id: 2, onCall: { order.append($0) }),
+            OrderingStub(id: 3, onCall: { order.append($0) }),
+        ]
+        let multi = MultiTTIMetricsReceiver<String>(
+            screenIdentifier: { _ in nil },
+            receivers: receivers
+        )
+        multi.ttiMetricsReceived(
+            metrics: TTIMetrics(tti: .seconds(1), ttfr: .milliseconds(500), appStartInfo: .empty),
+            screen: "x"
+        )
+
+        XCTAssertEqual(order, [1, 2, 3])
+    }
+}

--- a/PerformanceSuite/Tests/MultiWatchdogTerminationsReceiverTests.swift
+++ b/PerformanceSuite/Tests/MultiWatchdogTerminationsReceiverTests.swift
@@ -1,0 +1,70 @@
+//
+//  MultiWatchdogTerminationsReceiverTests.swift
+//  PerformanceSuite-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import UIKit
+import XCTest
+@testable import PerformanceSuite
+
+final class MultiWatchdogTerminationsReceiverTests: XCTestCase {
+
+    private final class WatchdogStub: WatchdogTerminationsReceiver {
+        var received: [WatchdogTerminationData] = []
+        func watchdogTerminationReceived(_ data: WatchdogTerminationData) {
+            received.append(data)
+        }
+    }
+
+    private func makeData() -> WatchdogTerminationData {
+        WatchdogTerminationData(
+            applicationState: .active,
+            appStartInfo: .empty,
+            duringStartup: false,
+            memoryWarnings: 2
+        )
+    }
+
+    func testFanOutToAllReceivers() {
+        let first = WatchdogStub()
+        let second = WatchdogStub()
+        let multi = MultiWatchdogTerminationsReceiver(receivers: [first, second])
+
+        let data = makeData()
+        multi.watchdogTerminationReceived(data)
+
+        XCTAssertEqual(first.received.count, 1)
+        XCTAssertEqual(second.received.count, 1)
+        XCTAssertEqual(first.received.first?.applicationState, data.applicationState)
+        XCTAssertEqual(first.received.first?.memoryWarnings, data.memoryWarnings)
+    }
+
+    func testEmptyReceiversArrayDoesNotCrash() {
+        let multi = MultiWatchdogTerminationsReceiver(receivers: [])
+        multi.watchdogTerminationReceived(makeData())
+    }
+
+    func testOrderPreserved() {
+        var order: [Int] = []
+        final class OrderingStub: WatchdogTerminationsReceiver {
+            let id: Int
+            let onCall: (Int) -> Void
+            init(id: Int, onCall: @escaping (Int) -> Void) {
+                self.id = id
+                self.onCall = onCall
+            }
+            func watchdogTerminationReceived(_ data: WatchdogTerminationData) {
+                onCall(id)
+            }
+        }
+        let multi = MultiWatchdogTerminationsReceiver(receivers: [
+            OrderingStub(id: 100, onCall: { order.append($0) }),
+            OrderingStub(id: 101, onCall: { order.append($0) }),
+        ])
+        multi.watchdogTerminationReceived(makeData())
+
+        XCTAssertEqual(order, [100, 101])
+    }
+}


### PR DESCRIPTION
Adds additive composition primitives that let consumers fan a single performance signal out to multiple receivers without dispatch boilerplate, and exposes primary associated types on receiver protocols so heterogeneous receiver arrays become possible via constrained existentials (any P<X>).

New types in PerformanceSuite/Sources/Public/

  MultiTTIMetricsReceiver<Screen>            (iOS 16+)
  MultiRenderingMetricsReceiver<Screen>      (iOS 16+)
  MultiFragmentTTIMetricsReceiver<Fragment>  (iOS 16+)
  MultiAppRenderingMetricsReceiver           (iOS 15+)
  MultiStartupTimeReceiver                   (iOS 15+)
  MultiHangsReceiver                         (iOS 15+)
  MultiWatchdogTerminationsReceiver          (iOS 15+)

Primary associated types added (additive, fully backward compatible)

  ScreenMetricsReceiver<ScreenIdentifier>
  TTIMetricsReceiver<ScreenIdentifier>
  RenderingMetricsReceiver<ScreenIdentifier>
  ViewControllerLoggingReceiver<ScreenIdentifier>
  FragmentTTIMetricsReceiver<FragmentIdentifier>

Subprotocols do not inherit primary associated types from a parent in Swift, so each must declare its own. Existing conformances, existing 'any P' usages, and existing Config code are all unaffected. The only new capability is that 'any TTIMetricsReceiver<PerformanceScreen>' (and similar) becomes a valid type, enabling arrays of heterogeneous receivers with the same identifier - needed by the upcoming PerformanceSuiteOTel library for dual-emit configurations.

iOS 16 runtime requirement

Parameterized existentials compile on iOS 15 but their runtime support shipped with iOS 16 (SE-0353). The three Multi receivers that store [any P<X>] arrays are therefore gated with @available(iOS 16.0, *). The remaining four Multi receivers work on iOS 15 because their underlying protocols have no associated types. The package's iOS 15 deployment target is preserved; no existing API is gated.

Design notes

* screenIdentifier(for:) is supplied to each generic Multi receiver as a separate closure rather than delegated to one of the wrapped receivers. This avoids ambiguity about whose mapping wins when the wrapped receivers disagree, and lets callers reuse a single screen- identifier implementation across multiple Multi receiver instances.
* MultiHangsReceiver captures hangThreshold at init from the first receiver. HangReporter reads the threshold once at config time to schedule its detection timer, so dynamic forwarding would silently change behaviour if a receiver mutated its threshold after init. Tested for stability under post-init mutation.