### PR TITLE
Add PerformanceSuiteOTel: OpenTelemetry adapter for PerformanceSuite

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -118,12 +118,30 @@
       }
     },
     {
+      "identity" : "opentelemetry-swift-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
+      "state" : {
+        "revision" : "84b9e341cbb7b4dd62cd1b89cd9e008995084132",
+        "version" : "2.4.1"
+      }
+    },
+    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,9 @@ let package = Package(
         .library(
             name: "PerformanceSuiteCrashlytics",
             targets: ["PerformanceSuiteCrashlytics"]),
+        .library(
+            name: "PerformanceSuiteOTel",
+            targets: ["PerformanceSuiteOTel"]),
         .executable(
             name: "PerformanceApp",
             targets: ["PerformanceApp"]
@@ -22,6 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "10.0.0"..<"13.0.0"),
         .package(url: "https://github.com/yene/GCDWebServer", exact: .init(3, 5, 7)),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.0.0"),
     ],
     targets: [
         .target(
@@ -38,6 +42,14 @@ let package = Package(
                 .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk"),
             ],
             path: "PerformanceSuite/Crashlytics/Sources"
+        ),
+        .target(
+            name: "PerformanceSuiteOTel",
+            dependencies: [
+                "PerformanceSuite",
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+            ],
+            path: "PerformanceSuite/OTel/Sources"
         ),
         .target(name: "CrashlyticsImports",
                 dependencies: [

--- a/PerformanceSuite.podspec
+++ b/PerformanceSuite.podspec
@@ -22,6 +22,12 @@ Pod::Spec.new do |s|
     cr_spec.dependency 'FirebaseCrashlytics'
   end
 
+  s.subspec 'OTel' do |otel_spec|
+    otel_spec.source_files = 'PerformanceSuite/OTel/Sources/*.swift'
+    otel_spec.dependency 'PerformanceSuite/Core'
+    otel_spec.dependency 'OpenTelemetry-Swift-Api', '~> 2.0'
+  end
+
   # Sample App which is also used for UI tests as a host
   s.app_spec 'PerformanceApp' do |app_spec|
     app_spec.source_files = 'PerformanceSuite/PerformanceApp/**/*.swift'
@@ -29,11 +35,13 @@ Pod::Spec.new do |s|
     app_spec.dependency 'PerformanceSuite/Crashlytics'
   end
 
-  # Unit tests
+  # Unit tests — OTel tests live under PerformanceSuite/OTel/Tests/ and are
+  # folded into the same Tests scheme so all unit tests run as one xctest.
   s.test_spec 'Tests' do |test_spec|
     test_spec.requires_app_host = true
-    test_spec.source_files = 'PerformanceSuite/Tests/**/*.swift'
+    test_spec.source_files = 'PerformanceSuite/Tests/**/*.swift', 'PerformanceSuite/OTel/Tests/**/*.swift'
     test_spec.dependency 'PerformanceSuite/Crashlytics'
+    test_spec.dependency 'PerformanceSuite/OTel'
   end
 
   # UI Tests

--- a/PerformanceSuite/OTel/Sources/OTelInstrumenter.swift
+++ b/PerformanceSuite/OTel/Sources/OTelInstrumenter.swift
@@ -22,9 +22,7 @@ import PerformanceSuite
 /// `OTelInstrumenter` conforms to **all** PerformanceSuite receiver protocols
 /// and emits one OTel span per signal received. Spans are recorded as completed
 /// (start time + end time set together at emission), which is the simplest
-/// shape that flows through any standard OTel pipeline. Phase 2 of the RFC
-/// adds *live* spans on top of this; see
-/// `docs/2026-04-16-plan-perfsuite-otel-live-spans.md`.
+/// shape that flows through any standard OTel pipeline.
 ///
 /// ## Generic parameters
 ///
@@ -51,7 +49,7 @@ import PerformanceSuite
 /// provider is injected. PerformanceSuite typically initialises before the
 /// OTel SDK (for example the Embrace SDK in BookingObservability), so eager
 /// resolution would freeze the no-op `DefaultTracerProvider` and silently drop
-/// every span. See RFC §9 for the full ordering analysis.
+/// every span.
 ///
 /// ## Identifier conversion
 ///
@@ -176,7 +174,7 @@ public final class OTelInstrumenter<Screen, Fragment>:
     // MARK: - StartupTimeReceiver
 
     public func startupTimeReceived(_ data: StartupTimeData) {
-        // Per RFC §7 / §11 finding F-12: the OTel side always emits, even on
+        // The OTel side always emits, even on
         // prewarmed launches. The `app.startup.prewarmed` attribute lets
         // backends filter or weight prewarm samples instead of dropping them.
         emitter.emitStartupSpan(data: data)

--- a/PerformanceSuite/OTel/Sources/OTelInstrumenter.swift
+++ b/PerformanceSuite/OTel/Sources/OTelInstrumenter.swift
@@ -1,0 +1,226 @@
+//
+//  OTelInstrumenter.swift
+//  PerformanceSuiteOTel
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+import UIKit
+
+// In SwiftPM `PerformanceSuiteOTel` is its own target, so we must explicitly
+// import the sibling `PerformanceSuite` module. In CocoaPods the OTel subspec
+// is compiled as part of the single `PerformanceSuite` framework, so the
+// `PerformanceSuite` types are already in scope and a self-import would fail.
+#if canImport(PerformanceSuiteOTel)
+import PerformanceSuite
+#endif
+
+/// Adapter that turns every PerformanceSuite metric into an OpenTelemetry span.
+///
+/// `OTelInstrumenter` conforms to **all** PerformanceSuite receiver protocols
+/// and emits one OTel span per signal received. Spans are recorded as completed
+/// (start time + end time set together at emission), which is the simplest
+/// shape that flows through any standard OTel pipeline. Phase 2 of the RFC
+/// adds *live* spans on top of this; see
+/// `docs/2026-04-16-plan-perfsuite-otel-live-spans.md`.
+///
+/// ## Generic parameters
+///
+/// `OTelInstrumenter` is generic over the host app's `Screen` and `Fragment`
+/// identifier types. The generics avoid `Any` at the boundary so the
+/// instrumenter can be wrapped inside ``MultiTTIMetricsReceiver`` /
+/// ``MultiFragmentTTIMetricsReceiver`` without losing the type's screen
+/// identity.
+///
+/// For an OTel-only setup with view-controller-typed screens, instantiate
+/// directly with no parameters:
+///
+///     let otel = OTelInstrumenter<UIViewController, String>()
+///
+/// For a typed setup that participates in dual-emit via a `Multi*Receiver`,
+/// pass `Screen` / `Fragment` matching the rest of the app's config (the
+/// `screenIdentifier` closure is then provided by the multi-receiver, so
+/// `OTelInstrumenter` can leave it unset).
+///
+/// ## TracerProvider resolution
+///
+/// The OTel tracer is **lazily** fetched from the global
+/// `OpenTelemetry.instance.tracerProvider` at first emission unless an explicit
+/// provider is injected. PerformanceSuite typically initialises before the
+/// OTel SDK (for example the Embrace SDK in BookingObservability), so eager
+/// resolution would freeze the no-op `DefaultTracerProvider` and silently drop
+/// every span. See RFC §9 for the full ordering analysis.
+///
+/// ## Identifier conversion
+///
+/// Span names embed the screen / fragment identifier as a string. For
+/// `String`-backed `RawRepresentable` enums (the common case in the host app)
+/// the `rawValue` is used; otherwise the value is rendered via
+/// `String(describing:)`. This matches the semantics used by the existing
+/// PerformanceSuite squeak path and keeps OTel span names stable across
+/// renames in Swift code.
+public final class OTelInstrumenter<Screen, Fragment>:
+    TTIMetricsReceiver,
+    RenderingMetricsReceiver,
+    FragmentTTIMetricsReceiver,
+    AppRenderingMetricsReceiver,
+    StartupTimeReceiver,
+    HangsReceiver,
+    WatchdogTerminationsReceiver {
+    public typealias ScreenIdentifier = Screen
+    public typealias FragmentIdentifier = Fragment
+
+    private let _screenIdentifier: ((UIViewController) -> Screen?)?
+    private let emitter: OTelSpanEmitter
+
+    /// - Parameters:
+    ///   - screenIdentifier: Optional closure to map view controllers to
+    ///     `Screen`. When `nil`:
+    ///       * If `Screen == UIViewController`, the default behaviour
+    ///         (track main-bundle view controllers) is used — matching
+    ///         PerformanceSuite's own default.
+    ///       * Otherwise this method returns `nil`, which is the right
+    ///         behaviour when the instrumenter is wrapped inside a
+    ///         `Multi*Receiver` whose own closure is the source of truth.
+    ///   - tracerProvider: Inject a custom provider for tests or special
+    ///     setups. When `nil`, the global `OpenTelemetry.instance.tracerProvider`
+    ///     is resolved at first emission.
+    ///   - instrumentationName: Reported on every span. Backends use this to
+    ///     filter PerformanceSuite spans. Defaults to `"perfsuite-ios"`.
+    ///   - instrumentationVersion: Optional version string reported alongside
+    ///     the instrumentation name.
+    ///   - spanNamePrefix: Optional prefix prepended to every span name with a
+    ///     dot separator. For example, `"bookingcom"` turns `"app-startup"`
+    ///     into `"bookingcom.app-startup"`. Useful when multiple apps share an
+    ///     OTel pipeline and need namespaced span names. `nil` (the default)
+    ///     emits unprefixed names.
+    public init(
+        screenIdentifier: ((UIViewController) -> Screen?)? = nil,
+        tracerProvider: (any TracerProvider)? = nil,
+        instrumentationName: String = OTelSemanticConventions.defaultInstrumentationName,
+        instrumentationVersion: String? = nil,
+        spanNamePrefix: String? = nil
+    ) {
+        self._screenIdentifier = screenIdentifier
+        self.emitter = OTelSpanEmitter(
+            tracerProvider: tracerProvider,
+            instrumentationName: instrumentationName,
+            instrumentationVersion: instrumentationVersion,
+            spanNamePrefix: spanNamePrefix
+        )
+    }
+
+    /// Test-only initializer that allows injecting a deterministic clock.
+    init(
+        screenIdentifier: ((UIViewController) -> Screen?)?,
+        tracerProvider: (any TracerProvider)?,
+        instrumentationName: String,
+        instrumentationVersion: String?,
+        spanNamePrefix: String? = nil,
+        now: @escaping () -> Date
+    ) {
+        self._screenIdentifier = screenIdentifier
+        self.emitter = OTelSpanEmitter(
+            tracerProvider: tracerProvider,
+            instrumentationName: instrumentationName,
+            instrumentationVersion: instrumentationVersion,
+            spanNamePrefix: spanNamePrefix,
+            now: now
+        )
+    }
+
+    // MARK: - ScreenMetricsReceiver
+
+    public func screenIdentifier(for viewController: UIViewController) -> Screen? {
+        if let provider = _screenIdentifier {
+            return provider(viewController)
+        }
+        if Screen.self == UIViewController.self {
+            // Mirror PerformanceSuite's default: track view controllers from
+            // the main bundle only.
+            guard Bundle(for: type(of: viewController)) == Bundle.main else { return nil }
+            return viewController as? Screen
+        }
+        // The instrumenter is being used as part of a Multi*Receiver — the
+        // screenIdentifier closure on the multi-receiver supplies the mapping,
+        // and PerformanceSuite never calls this method on us directly.
+        return nil
+    }
+
+    // MARK: - TTIMetricsReceiver
+
+    public func ttiMetricsReceived(metrics: TTIMetrics, screen: Screen) {
+        emitter.emitScreenTTISpan(screenName: identifierName(screen), metrics: metrics)
+    }
+
+    // MARK: - RenderingMetricsReceiver
+
+    public func renderingMetricsReceived(metrics: RenderingMetrics, screen: Screen) {
+        emitter.emitScreenRenderingSpan(screenName: identifierName(screen), metrics: metrics)
+    }
+
+    // MARK: - FragmentTTIMetricsReceiver
+
+    public func fragmentTTIMetricsReceived(metrics: TTIMetrics, fragment: Fragment) {
+        emitter.emitFragmentTTISpan(fragmentName: identifierName(fragment), metrics: metrics)
+    }
+
+    // MARK: - AppRenderingMetricsReceiver
+
+    public func appRenderingMetricsReceived(metrics: RenderingMetrics) {
+        emitter.emitAppRenderingSpan(metrics: metrics)
+    }
+
+    // MARK: - StartupTimeReceiver
+
+    public func startupTimeReceived(_ data: StartupTimeData) {
+        // Per RFC §7 / §11 finding F-12: the OTel side always emits, even on
+        // prewarmed launches. The `app.startup.prewarmed` attribute lets
+        // backends filter or weight prewarm samples instead of dropping them.
+        emitter.emitStartupSpan(data: data)
+    }
+
+    // MARK: - HangsReceiver
+
+    public func fatalHangReceived(info: HangInfo) {
+        emitter.emitHangSpan(info: info, type: OTelSemanticConventions.HangType.fatal)
+    }
+
+    public func nonFatalHangReceived(info: HangInfo) {
+        emitter.emitHangSpan(info: info, type: OTelSemanticConventions.HangType.nonFatal)
+    }
+
+    public func hangStarted(info: HangInfo) {
+        // `hangStarted` is an in-progress signal; no completed span to record.
+        // Phase 2 (live spans) will turn this into a span-start event.
+    }
+
+    // MARK: - WatchdogTerminationsReceiver
+
+    public func watchdogTerminationReceived(_ data: WatchdogTerminationData) {
+        emitter.emitWatchdogTerminationSpan(data: data)
+    }
+
+    // MARK: - Identifier conversion
+
+    /// Convert an arbitrary identifier to the string form used in span names
+    /// and attribute values.
+    ///
+    /// Strategy:
+    /// 1. If the identifier is a `String`-backed `RawRepresentable` (the common
+    ///    case for `enum Screen: String`), emit the raw value. This produces
+    ///    stable, dashboard-friendly names like `"search_results"` instead of
+    ///    Swift-mangled `"PerformanceScreen.searchResults"`.
+    /// 2. Otherwise fall back to `String(describing:)`. Acceptable for
+    ///    `String` identifiers (which become themselves) and for ad-hoc enum
+    ///    types.
+    private func identifierName<T>(_ identifier: T) -> String {
+        if let raw = identifier as? any RawRepresentable,
+           let str = raw.rawValue as? String {
+            return str
+        }
+        return String(describing: identifier)
+    }
+}

--- a/PerformanceSuite/OTel/Sources/OTelSemanticConventions.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSemanticConventions.swift
@@ -1,0 +1,104 @@
+//
+//  OTelSemanticConventions.swift
+//  PerformanceSuiteOTel
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+
+/// Span names and attribute keys used by ``OTelInstrumenter`` when emitting
+/// PerformanceSuite metrics as OpenTelemetry spans.
+///
+/// Centralising these as constants gives consumers a single place to reference
+/// when building backend dashboards or alerting rules. Constants are namespaced
+/// by concern (`SpanName`, `Attribute`) so call sites stay readable:
+///
+///     spanBuilder.setAttribute(
+///         key: OTelSemanticConventions.Attribute.screenTTIMs,
+///         value: ttiMilliseconds
+///     )
+public enum OTelSemanticConventions {
+
+    public enum SpanName {
+        public static let appStartup = "app-startup"
+        public static let appRendering = "app-rendering"
+        public static let appHang = "app-hang"
+        public static let appWatchdogTermination = "app-watchdog-termination"
+
+        public static func screenTTI(_ screenName: String) -> String {
+            "screen-tti.\(screenName)"
+        }
+
+        public static func fragmentTTI(_ fragmentName: String) -> String {
+            "fragment-tti.\(fragmentName)"
+        }
+
+        public static func screenRendering(_ screenName: String) -> String {
+            "screen-rendering.\(screenName)"
+        }
+    }
+
+    public enum Attribute {
+        // Startup
+        public static let startupTotalTimeMs = "app.startup.total_time.ms"
+        public static let startupMainTimeMs = "app.startup.main_time.ms"
+        public static let startupPremainTimeMs = "app.startup.premain_time.ms"
+        public static let startupPrewarmed = "app.startup.prewarmed"
+
+        // Screen TTI
+        public static let screenName = "screen.name"
+        public static let screenTTIMs = "screen.tti.ms"
+        public static let screenTTFRMs = "screen.ttfr.ms"
+
+        // Fragment TTI
+        public static let fragmentName = "fragment.name"
+        public static let fragmentTTIMs = "fragment.tti.ms"
+        public static let fragmentTTFRMs = "fragment.ttfr.ms"
+
+        // Rendering (screen-level + app-level share these keys)
+        public static let renderingTotalFrames = "rendering.total_frames"
+        public static let renderingDroppedFrames = "rendering.dropped_frames"
+        public static let renderingSlowFrames = "rendering.slow_frames"
+        public static let renderingFreezeTimeMs = "rendering.freeze_time.ms"
+        public static let renderingSessionDurationMs = "rendering.session_duration.ms"
+
+        // Hangs
+        public static let hangType = "hang.type"
+        public static let hangDurationMs = "hang.duration.ms"
+        public static let hangDuringStartup = "hang.during_startup"
+        public static let hangTopScreen = "hang.top_screen"
+
+        // Watchdog termination
+        public static let appState = "app.state"
+        public static let memoryWarningsCount = "memory.warnings_count"
+        public static let deviceRamMb = "device.ram.mb"
+
+        // Device / OS (set on app-level spans where useful)
+        public static let deviceModel = "device.model"
+        public static let osName = "os.name"
+        public static let osVersion = "os.version"
+    }
+
+    /// String values that appear in the `hang.type` attribute. Kept narrow on
+    /// purpose so backend dashboards don't accumulate freeform variants.
+    public enum HangType {
+        public static let fatal = "fatal"
+        public static let nonFatal = "non_fatal"
+    }
+
+    /// Strings emitted in the `app.state` attribute on watchdog-termination
+    /// spans, mirroring the cases of `UIApplication.State`.
+    public enum AppState {
+        public static let active = "active"
+        public static let inactive = "inactive"
+        public static let background = "background"
+        public static let unknown = "unknown"
+    }
+
+    /// Stable string for the `os.name` attribute.
+    public static let osNameValue = "iOS"
+
+    /// Default instrumentation name reported on every ``OTelInstrumenter`` span.
+    public static let defaultInstrumentationName = "perfsuite-ios"
+}

--- a/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
@@ -27,7 +27,7 @@ import PerformanceSuite
 ///   initialises before the OTel SDK (Embrace) registers the global provider —
 ///   eagerly capturing `OpenTelemetry.instance.tracerProvider` at init time
 ///   would freeze the no-op `DefaultTracerProvider` and silently drop every
-///   span. See RFC §9 for the initialization-ordering analysis.
+///   span.
 /// * `setNoParent()` is called on every span. PerformanceSuite metrics are
 ///   leaf measurements with no caller-scoped active span; explicitly making
 ///   them root spans avoids accidental parent linkage to whatever happens to

--- a/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
@@ -1,0 +1,322 @@
+//
+//  OTelSpanEmitter.swift
+//  PerformanceSuiteOTel
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+import UIKit
+
+// In SwiftPM we import the sibling `PerformanceSuite` module; in CocoaPods all
+// subspec sources live in one module so this import would be a self-reference.
+#if canImport(PerformanceSuiteOTel)
+import PerformanceSuite
+#endif
+
+/// Internal helper that builds and finalises one OTel span per metric received
+/// from PerformanceSuite. Each public method on ``OTelInstrumenter`` delegates
+/// to one method here, keeping the instrumenter focused on protocol conformance
+/// and identifier conversion.
+///
+/// Design points:
+///
+/// * The `TracerProvider` is **lazily resolved at first emission**, not at
+///   construction. This is essential because PerformanceSuite typically
+///   initialises before the OTel SDK (Embrace) registers the global provider —
+///   eagerly capturing `OpenTelemetry.instance.tracerProvider` at init time
+///   would freeze the no-op `DefaultTracerProvider` and silently drop every
+///   span. See RFC §9 for the initialization-ordering analysis.
+/// * `setNoParent()` is called on every span. PerformanceSuite metrics are
+///   leaf measurements with no caller-scoped active span; explicitly making
+///   them root spans avoids accidental parent linkage to whatever happens to
+///   be active on the queue at emit time.
+/// * Span timing is computed as `(now - duration, now)` so that backends see
+///   wall-clock-aligned spans and a single batch retains causal ordering.
+final class OTelSpanEmitter {
+
+    private let tracerProvider: (any TracerProvider)?
+    private let instrumentationName: String
+    private let instrumentationVersion: String?
+    private let spanNamePrefix: String?
+    private let now: () -> Date
+
+    init(
+        tracerProvider: (any TracerProvider)?,
+        instrumentationName: String,
+        instrumentationVersion: String?,
+        spanNamePrefix: String? = nil,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.tracerProvider = tracerProvider
+        self.instrumentationName = instrumentationName
+        self.instrumentationVersion = instrumentationVersion
+        self.spanNamePrefix = spanNamePrefix
+        self.now = now
+    }
+
+    private func prefixed(_ name: String) -> String {
+        guard let spanNamePrefix, !spanNamePrefix.isEmpty else { return name }
+        return "\(spanNamePrefix).\(name)"
+    }
+
+    // MARK: - Tracer resolution
+
+    private func tracer() -> any Tracer {
+        let provider = tracerProvider ?? OpenTelemetry.instance.tracerProvider
+        return provider.get(
+            instrumentationName: instrumentationName,
+            instrumentationVersion: instrumentationVersion
+        )
+    }
+
+    // MARK: - Startup
+
+    func emitStartupSpan(data: StartupTimeData) {
+        let endTime = now()
+        let startTime = endTime.addingTimeInterval(-(data.totalTime.timeInterval ?? 0))
+
+        let builder = tracer()
+            .spanBuilder(spanName: prefixed(OTelSemanticConventions.SpanName.appStartup))
+            .setStartTime(time: startTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+
+        let attrs = OTelSemanticConventions.Attribute.self
+        if let ms = data.totalTime.milliseconds {
+            builder.setAttribute(key: attrs.startupTotalTimeMs, value: ms)
+        }
+        if let ms = data.mainTime?.milliseconds {
+            builder.setAttribute(key: attrs.startupMainTimeMs, value: ms)
+        }
+        if let ms = data.preMainTime?.milliseconds {
+            builder.setAttribute(key: attrs.startupPremainTimeMs, value: ms)
+        }
+        builder.setAttribute(key: attrs.startupPrewarmed, value: data.appStartInfo.appStartedWithPrewarming)
+
+        applyDeviceAttributes(to: builder)
+
+        let span = builder.startSpan()
+        span.end(time: endTime)
+    }
+
+    // MARK: - Screen TTI
+
+    func emitScreenTTISpan(screenName: String, metrics: TTIMetrics) {
+        emitTTISpan(
+            spanName: prefixed(OTelSemanticConventions.SpanName.screenTTI(screenName)),
+            keys: TTIAttributeKeys(
+                nameKey: OTelSemanticConventions.Attribute.screenName,
+                ttiKey: OTelSemanticConventions.Attribute.screenTTIMs,
+                ttfrKey: OTelSemanticConventions.Attribute.screenTTFRMs
+            ),
+            identifier: screenName,
+            metrics: metrics
+        )
+    }
+
+    // MARK: - Fragment TTI
+
+    func emitFragmentTTISpan(fragmentName: String, metrics: TTIMetrics) {
+        emitTTISpan(
+            spanName: prefixed(OTelSemanticConventions.SpanName.fragmentTTI(fragmentName)),
+            keys: TTIAttributeKeys(
+                nameKey: OTelSemanticConventions.Attribute.fragmentName,
+                ttiKey: OTelSemanticConventions.Attribute.fragmentTTIMs,
+                ttfrKey: OTelSemanticConventions.Attribute.fragmentTTFRMs
+            ),
+            identifier: fragmentName,
+            metrics: metrics
+        )
+    }
+
+    /// Bundles the three attribute keys that vary between screen TTI and
+    /// fragment TTI emission. Bundling keeps `emitTTISpan(...)` under
+    /// SwiftLint's 5-parameter limit and makes the call sites self-documenting.
+    private struct TTIAttributeKeys {
+        let nameKey: String
+        let ttiKey: String
+        let ttfrKey: String
+    }
+
+    private func emitTTISpan(
+        spanName: String,
+        keys: TTIAttributeKeys,
+        identifier: String,
+        metrics: TTIMetrics
+    ) {
+        let endTime = now()
+        let startTime = endTime.addingTimeInterval(-(metrics.tti.timeInterval ?? 0))
+
+        let builder = tracer()
+            .spanBuilder(spanName: spanName)
+            .setStartTime(time: startTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+            .setAttribute(key: keys.nameKey, value: identifier)
+
+        if let ms = metrics.tti.milliseconds {
+            builder.setAttribute(key: keys.ttiKey, value: ms)
+        }
+        if let ms = metrics.ttfr.milliseconds {
+            builder.setAttribute(key: keys.ttfrKey, value: ms)
+        }
+
+        let span = builder.startSpan()
+        span.end(time: endTime)
+    }
+
+    // MARK: - Screen rendering
+
+    func emitScreenRenderingSpan(screenName: String, metrics: RenderingMetrics) {
+        let endTime = now()
+        let startTime = endTime.addingTimeInterval(-(metrics.sessionDuration.timeInterval ?? 0))
+
+        let builder = tracer()
+            .spanBuilder(spanName: prefixed(OTelSemanticConventions.SpanName.screenRendering(screenName)))
+            .setStartTime(time: startTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+            .setAttribute(key: OTelSemanticConventions.Attribute.screenName, value: screenName)
+
+        applyRenderingAttributes(to: builder, metrics: metrics)
+
+        let span = builder.startSpan()
+        span.end(time: endTime)
+    }
+
+    // MARK: - App rendering
+
+    func emitAppRenderingSpan(metrics: RenderingMetrics) {
+        let endTime = now()
+        let startTime = endTime.addingTimeInterval(-(metrics.sessionDuration.timeInterval ?? 0))
+
+        let builder = tracer()
+            .spanBuilder(spanName: prefixed(OTelSemanticConventions.SpanName.appRendering))
+            .setStartTime(time: startTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+
+        applyRenderingAttributes(to: builder, metrics: metrics)
+
+        let span = builder.startSpan()
+        span.end(time: endTime)
+    }
+
+    private func applyRenderingAttributes(to builder: SpanBuilder, metrics: RenderingMetrics) {
+        let attrs = OTelSemanticConventions.Attribute.self
+        builder.setAttribute(key: attrs.renderingTotalFrames, value: metrics.renderedFrames)
+        builder.setAttribute(key: attrs.renderingDroppedFrames, value: metrics.droppedFrames)
+        builder.setAttribute(key: attrs.renderingSlowFrames, value: metrics.slowFrames)
+        if let ms = metrics.freezeTime.milliseconds {
+            builder.setAttribute(key: attrs.renderingFreezeTimeMs, value: ms)
+        }
+        if let ms = metrics.sessionDuration.milliseconds {
+            builder.setAttribute(key: attrs.renderingSessionDurationMs, value: ms)
+        }
+    }
+
+    // MARK: - Hangs
+
+    func emitHangSpan(info: HangInfo, type: String) {
+        let endTime = now()
+        let startTime = endTime.addingTimeInterval(-(info.duration.timeInterval ?? 0))
+
+        let builder = tracer()
+            .spanBuilder(spanName: prefixed(OTelSemanticConventions.SpanName.appHang))
+            .setStartTime(time: startTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+            .setAttribute(key: OTelSemanticConventions.Attribute.hangType, value: type)
+            .setAttribute(key: OTelSemanticConventions.Attribute.hangDuringStartup, value: info.duringStartup)
+
+        if let ms = info.duration.milliseconds {
+            builder.setAttribute(key: OTelSemanticConventions.Attribute.hangDurationMs, value: ms)
+        }
+        if let topScreen = info.appRuntimeInfo.openedScreens.last {
+            builder.setAttribute(key: OTelSemanticConventions.Attribute.hangTopScreen, value: topScreen)
+        }
+
+        let span = builder.startSpan()
+        span.end(time: endTime)
+    }
+
+    // MARK: - Watchdog termination
+
+    func emitWatchdogTerminationSpan(data: WatchdogTerminationData) {
+        // Watchdog terminations are detected on the *next* launch. There is no
+        // meaningful duration to compute — record as a zero-length point span at
+        // the moment of detection.
+        let pointInTime = now()
+
+        let builder = tracer()
+            .spanBuilder(spanName: prefixed(OTelSemanticConventions.SpanName.appWatchdogTermination))
+            .setStartTime(time: pointInTime)
+            .setNoParent()
+            .setSpanKind(spanKind: .internal)
+
+        let attrs = OTelSemanticConventions.Attribute.self
+        builder.setAttribute(key: attrs.appState, value: stringFrom(applicationState: data.applicationState))
+        if let warnings = data.memoryWarnings {
+            builder.setAttribute(key: attrs.memoryWarningsCount, value: warnings)
+        }
+        builder.setAttribute(key: attrs.deviceRamMb, value: Int(physicalMemoryMb()))
+
+        applyDeviceAttributes(to: builder)
+
+        let span = builder.startSpan()
+        span.end(time: pointInTime)
+    }
+
+    // MARK: - Device / OS attributes
+
+    private func applyDeviceAttributes(to builder: SpanBuilder) {
+        let attrs = OTelSemanticConventions.Attribute.self
+        builder.setAttribute(key: attrs.osName, value: OTelSemanticConventions.osNameValue)
+        builder.setAttribute(key: attrs.osVersion, value: UIDevice.current.systemVersion)
+        builder.setAttribute(key: attrs.deviceModel, value: deviceModelCode())
+    }
+
+    /// Hardware model code such as `"iPhone15,3"` (vs. the marketing name
+    /// `UIDevice.current.model` returns, which is just `"iPhone"`). Pulled from
+    /// `utsname.machine`. Falls back to `UIDevice.current.model` if the syscall
+    /// is somehow unavailable.
+    private func deviceModelCode() -> String {
+        var systemInfo = utsname()
+        guard uname(&systemInfo) == 0 else {
+            return UIDevice.current.model
+        }
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce(into: "") { acc, element in
+            guard let value = element.value as? Int8, value != 0 else { return }
+            acc.append(Character(UnicodeScalar(UInt8(value))))
+        }
+        return identifier.isEmpty ? UIDevice.current.model : identifier
+    }
+
+    private func physicalMemoryMb() -> UInt64 {
+        ProcessInfo.processInfo.physicalMemory / (1024 * 1024)
+    }
+
+    private func stringFrom(applicationState: UIApplication.State?) -> String {
+        guard let applicationState else {
+            return OTelSemanticConventions.AppState.unknown
+        }
+        switch applicationState {
+        case .active:
+            return OTelSemanticConventions.AppState.active
+        case .inactive:
+            return OTelSemanticConventions.AppState.inactive
+        case .background:
+            return OTelSemanticConventions.AppState.background
+        @unknown default:
+            return OTelSemanticConventions.AppState.unknown
+        }
+    }
+}
+
+// We re-use `DispatchTimeInterval.timeInterval` and `DispatchTimeInterval.milliseconds`
+// from PerformanceSuite (Sources/Utils/DispatchTimeInterval+Helpers.swift). When those
+// helpers return `nil` (for `.never` / unknown cases), the emitter treats the duration
+// as zero so spans always have well-formed `startTime <= endTime` timestamps.

--- a/PerformanceSuite/OTel/Tests/Mocks/MockSpan.swift
+++ b/PerformanceSuite/OTel/Tests/Mocks/MockSpan.swift
@@ -1,0 +1,159 @@
+//
+//  MockSpan.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/// Captured `addEvent` invocation, swapped for what would otherwise be a
+/// `(name, attributes, timestamp)` 3-tuple inside ``MockSpan``. Wrapping it in
+/// a struct keeps SwiftLint's `large_tuple` rule happy and makes assertions in
+/// future tests (when needed) read more naturally than tuple-element access.
+struct RecordedEvent {
+    let name: String
+    let attributes: [String: AttributeValue]
+    let timestamp: Date?
+}
+
+/// Test double for `Span`. Captures the attributes that were set at build time
+/// (passed in by ``MockSpanBuilder``) plus any attributes added after start,
+/// and records every `end()` / `end(time:)` invocation. Other protocol surface
+/// (`addEvent`, `recordException`, status / name mutation) is implemented as
+/// no-op-but-recordable for completeness — none of the current tests assert
+/// against those, but having the surface stops the compiler from rejecting
+/// conformance and avoids surprises if future tests reach for them.
+final class MockSpan: Span {
+
+    // MARK: - SpanBase requirements
+
+    var kind: SpanKind
+    var context: SpanContext
+    var isRecording: Bool = true
+    var status: Status = .unset
+    var name: String
+
+    // MARK: - Recording state
+
+    let startTime: Date?
+    private(set) var endCalls: [Date] = []
+    private(set) var attributes: [String: AttributeValue]
+    private(set) var events: [RecordedEvent] = []
+
+    /// `true` after any flavour of `end` is called.
+    var ended: Bool { !endCalls.isEmpty }
+
+    /// The first explicit end timestamp seen, if any. `end()` (no time) records
+    /// the value `MockSpan.endWithoutExplicitTimeMarker`.
+    var firstEndTime: Date? { endCalls.first }
+
+    static let endWithoutExplicitTimeMarker = Date.distantPast
+
+    init(name: String, kind: SpanKind, startTime: Date?, attributes: [String: AttributeValue]) {
+        self.name = name
+        self.kind = kind
+        self.startTime = startTime
+        self.attributes = attributes
+        // A default-init `SpanContext` is invalid (`isValid == false`) and that
+        // is fine for our test purposes — nothing in the emitter under test
+        // reads it. Using a random one would also work but invalid is cheaper.
+        self.context = SpanContext.create(
+            traceId: TraceId(),
+            spanId: SpanId(),
+            traceFlags: TraceFlags(),
+            traceState: TraceState()
+        )
+    }
+
+    // MARK: - Attributes
+
+    func setAttribute(key: String, value: AttributeValue?) {
+        if let value {
+            attributes[key] = value
+        } else {
+            attributes.removeValue(forKey: key)
+        }
+    }
+
+    func setAttributes(_ attributes: [String: AttributeValue]) {
+        self.attributes.merge(attributes) { _, new in new }
+    }
+
+    // MARK: - Events
+
+    func addEvent(name: String) {
+        events.append(RecordedEvent(name: name, attributes: [:], timestamp: nil))
+    }
+
+    func addEvent(name: String, timestamp: Date) {
+        events.append(RecordedEvent(name: name, attributes: [:], timestamp: timestamp))
+    }
+
+    func addEvent(name: String, attributes: [String: AttributeValue]) {
+        events.append(RecordedEvent(name: name, attributes: attributes, timestamp: nil))
+    }
+
+    func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {
+        events.append(RecordedEvent(name: name, attributes: attributes, timestamp: timestamp))
+    }
+
+    // MARK: - Exception recording (no-op stubs)
+
+    func recordException(_ exception: SpanException) {}
+    func recordException(_ exception: SpanException, timestamp: Date) {}
+    func recordException(_ exception: SpanException, attributes: [String: AttributeValue]) {}
+    func recordException(_ exception: SpanException, attributes: [String: AttributeValue], timestamp: Date) {}
+
+    // MARK: - End
+
+    func end() {
+        endCalls.append(MockSpan.endWithoutExplicitTimeMarker)
+        isRecording = false
+    }
+
+    func end(time: Date) {
+        endCalls.append(time)
+        isRecording = false
+    }
+
+    // MARK: - CustomStringConvertible
+
+    var description: String { "MockSpan(name=\(name))" }
+}
+
+// MARK: - AttributeValue convenience accessors for tests
+
+extension AttributeValue {
+    /// Returns the `Int` value if this attribute is an `.int(...)`. Tests use
+    /// this to assert numeric attributes without pattern-matching at every
+    /// call site.
+    var intValue: Int? {
+        if case let .int(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var stringValue: String? {
+        if case let .string(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case let .bool(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    var doubleValue: Double? {
+        if case let .double(value) = self {
+            return value
+        }
+        return nil
+    }
+}

--- a/PerformanceSuite/OTel/Tests/Mocks/MockSpanBuilder.swift
+++ b/PerformanceSuite/OTel/Tests/Mocks/MockSpanBuilder.swift
@@ -1,0 +1,111 @@
+//
+//  MockSpanBuilder.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/// Test double for `SpanBuilder`. Captures every chainable setter (start time,
+/// attributes, span kind, parent mode), then hands a captured ``MockSpan`` to
+/// `startSpan`. Most tests inspect the builder for attribute values and the
+/// span for `end(time:)` invocations.
+final class MockSpanBuilder: SpanBuilder {
+
+    enum ParentMode: Equatable {
+        case unset
+        case noParent
+        case parentSpanReference
+        case parentContextReference
+    }
+
+    let spanName: String
+
+    private(set) var startTime: Date?
+    private(set) var spanKind: SpanKind?
+    private(set) var parentMode: ParentMode = .unset
+    private(set) var attributes: [String: AttributeValue] = [:]
+    private(set) var startedSpan: MockSpan?
+
+    init(spanName: String) {
+        self.spanName = spanName
+    }
+
+    // MARK: - Parent / linking
+
+    @discardableResult
+    func setParent(_ parent: any Span) -> Self {
+        parentMode = .parentSpanReference
+        return self
+    }
+
+    @discardableResult
+    func setParent(_ parent: SpanContext) -> Self {
+        parentMode = .parentContextReference
+        return self
+    }
+
+    @discardableResult
+    func setNoParent() -> Self {
+        parentMode = .noParent
+        return self
+    }
+
+    @discardableResult
+    func addLink(spanContext: SpanContext) -> Self { self }
+
+    @discardableResult
+    func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) -> Self { self }
+
+    // MARK: - Attributes
+
+    @discardableResult
+    func setAttribute(key: String, value: AttributeValue) -> Self {
+        attributes[key] = value
+        return self
+    }
+
+    // MARK: - Span kind / start time
+
+    @discardableResult
+    func setSpanKind(spanKind: SpanKind) -> Self {
+        self.spanKind = spanKind
+        return self
+    }
+
+    @discardableResult
+    func setStartTime(time: Date) -> Self {
+        startTime = time
+        return self
+    }
+
+    // MARK: - Active
+
+    @discardableResult
+    func setActive(_ active: Bool) -> Self { self }
+
+    // MARK: - Start
+
+    func startSpan() -> any Span {
+        let span = MockSpan(name: spanName, kind: spanKind ?? .internal, startTime: startTime, attributes: attributes)
+        startedSpan = span
+        return span
+    }
+
+    // MARK: - Active-span helpers (no defaults exist on the protocol)
+
+    func withActiveSpan<T>(_ operation: (any SpanBase) throws -> T) rethrows -> T {
+        let span = startSpan()
+        defer { span.end() }
+        return try operation(span)
+    }
+
+    @available(iOS 13.0, *)
+    func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
+        let span = startSpan()
+        defer { span.end() }
+        return try await operation(span)
+    }
+}

--- a/PerformanceSuite/OTel/Tests/Mocks/MockTracer.swift
+++ b/PerformanceSuite/OTel/Tests/Mocks/MockTracer.swift
@@ -1,0 +1,27 @@
+//
+//  MockTracer.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/// Test double for `Tracer`. Returns a fresh ``MockSpanBuilder`` per call and
+/// keeps every builder around so tests can assert on the resulting spans
+/// regardless of construction order.
+final class MockTracer: Tracer {
+
+    private(set) var builders: [MockSpanBuilder] = []
+
+    /// Convenience accessor — most tests look at "the most recently built
+    /// span" rather than iterating through every emission.
+    var lastBuilder: MockSpanBuilder? { builders.last }
+
+    func spanBuilder(spanName: String) -> SpanBuilder {
+        let builder = MockSpanBuilder(spanName: spanName)
+        builders.append(builder)
+        return builder
+    }
+}

--- a/PerformanceSuite/OTel/Tests/Mocks/MockTracerProvider.swift
+++ b/PerformanceSuite/OTel/Tests/Mocks/MockTracerProvider.swift
@@ -1,0 +1,41 @@
+//
+//  MockTracerProvider.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+/// Test double for `TracerProvider`. Records every `get` call and returns a
+/// shared ``MockTracer`` so tests can drill into the spans that were built.
+final class MockTracerProvider: TracerProvider {
+
+    struct GetCall: Equatable {
+        let instrumentationName: String
+        let instrumentationVersion: String?
+        let schemaUrl: String?
+        let attributes: [String: AttributeValue]?
+    }
+
+    private(set) var getCalls: [GetCall] = []
+    let tracer = MockTracer()
+
+    func get(
+        instrumentationName: String,
+        instrumentationVersion: String?,
+        schemaUrl: String?,
+        attributes: [String: AttributeValue]?
+    ) -> any Tracer {
+        getCalls.append(
+            GetCall(
+                instrumentationName: instrumentationName,
+                instrumentationVersion: instrumentationVersion,
+                schemaUrl: schemaUrl,
+                attributes: attributes
+            )
+        )
+        return tracer
+    }
+}

--- a/PerformanceSuite/OTel/Tests/OTelInstrumenterTests.swift
+++ b/PerformanceSuite/OTel/Tests/OTelInstrumenterTests.swift
@@ -1,0 +1,341 @@
+//
+//  OTelInstrumenterTests.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 30/04/2026.
+//
+
+import OpenTelemetryApi
+@testable import PerformanceSuite
+import UIKit
+import XCTest
+
+// In SwiftPM `PerformanceSuiteOTel` is its own module, so we testably import
+// it. In CocoaPods all OTel sources are part of `PerformanceSuite` and are
+// already exposed by the testable import above.
+#if canImport(PerformanceSuiteOTel)
+@testable import PerformanceSuiteOTel
+#endif
+
+/// Identifier enum used to verify that ``OTelInstrumenter`` extracts
+/// `rawValue` for `String`-backed `RawRepresentable` enums (the common case
+/// in the host app).
+private enum TestScreen: String {
+    case homescreen
+    case searchResults = "search_results"
+}
+
+/// Identifier without a `String` raw value — exercises the
+/// `String(describing:)` fallback path.
+private enum TestFragment: Equatable {
+    case header
+    case footer
+}
+
+final class OTelInstrumenterTests: XCTestCase {
+
+    // MARK: - Test setup helpers
+
+    /// Build an instrumenter that uses the supplied `MockTracerProvider` and a
+    /// fixed `now` clock so we can verify `start = end - duration` exactly,
+    /// without flakiness from real time passing during the test.
+    private func makeInstrumenter(
+        provider: MockTracerProvider,
+        now: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> OTelInstrumenter<TestScreen, TestFragment> {
+        OTelInstrumenter<TestScreen, TestFragment>(
+            screenIdentifier: nil,
+            tracerProvider: provider,
+            instrumentationName: "perfsuite-ios",
+            instrumentationVersion: "1.7.0",
+            now: { now }
+        )
+    }
+
+    private func metrics(tti ms: Int, ttfr ttfrMs: Int = 50) -> TTIMetrics {
+        TTIMetrics(
+            tti: .milliseconds(ms),
+            ttfr: .milliseconds(ttfrMs),
+            appStartInfo: .empty
+        )
+    }
+
+    private func renderingMetrics(sessionMs: Int = 4_000) -> RenderingMetrics {
+        RenderingMetrics(
+            renderedFrames: 240,
+            expectedFrames: 240,
+            droppedFrames: 5,
+            frozenFrames: 0,
+            slowFrames: 7,
+            freezeTime: .milliseconds(120),
+            sessionDuration: .milliseconds(sessionMs),
+            appStartInfo: .empty
+        )
+    }
+
+    private func startupData(prewarmed: Bool, totalMs: Int = 1_500) -> StartupTimeData {
+        StartupTimeData(
+            totalTime: .milliseconds(totalMs),
+            preMainTime: .milliseconds(300),
+            mainTime: .milliseconds(1_200),
+            totalBeforeViewControllerTime: .milliseconds(900),
+            mainBeforeViewControllerTime: .milliseconds(600),
+            appStartInfo: AppStartInfo(appStartedWithPrewarming: prewarmed)
+        )
+    }
+
+    // MARK: - Startup
+
+    func testStartupSpanEmittedWithExpectedNameAndAttributes() throws {
+        let provider = MockTracerProvider()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let instrumenter = makeInstrumenter(provider: provider, now: now)
+
+        instrumenter.startupTimeReceived(startupData(prewarmed: false))
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder, "Expected one span emitted")
+        XCTAssertEqual(builder.spanName, "app-startup")
+        XCTAssertEqual(builder.spanKind, .internal)
+        XCTAssertEqual(builder.parentMode, .noParent)
+
+        XCTAssertEqual(builder.attributes["app.startup.total_time.ms"]?.intValue, 1_500)
+        XCTAssertEqual(builder.attributes["app.startup.main_time.ms"]?.intValue, 1_200)
+        XCTAssertEqual(builder.attributes["app.startup.premain_time.ms"]?.intValue, 300)
+        XCTAssertEqual(builder.attributes["app.startup.prewarmed"]?.boolValue, false)
+        XCTAssertEqual(builder.attributes["os.name"]?.stringValue, "iOS")
+        XCTAssertNotNil(builder.attributes["device.model"]?.stringValue)
+        XCTAssertNotNil(builder.attributes["os.version"]?.stringValue)
+
+        let span = try XCTUnwrap(builder.startedSpan)
+        XCTAssertTrue(span.ended, "Span must be ended after emission")
+        XCTAssertEqual(span.firstEndTime, now)
+        let startTime = try XCTUnwrap(builder.startTime)
+        XCTAssertEqual(startTime.timeIntervalSince1970,
+                       now.addingTimeInterval(-1.5).timeIntervalSince1970,
+                       accuracy: 0.001,
+                       "startTime must be (now - totalTime)")
+    }
+
+    func testStartupSpanIncludesPrewarmedTrueAttribute() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.startupTimeReceived(startupData(prewarmed: true))
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(
+            builder.attributes["app.startup.prewarmed"]?.boolValue, true,
+            "OTel side always emits, including for prewarmed launches (RFC §11 F-12)"
+        )
+    }
+
+    // MARK: - Screen TTI
+
+    func testScreenTTISpanEmittedWithRawValueInName() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.ttiMetricsReceived(metrics: metrics(tti: 800), screen: .searchResults)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "screen-tti.search_results",
+                       "Screen identifier must be the rawValue, not the Swift case name")
+        XCTAssertEqual(builder.spanKind, .internal)
+        XCTAssertEqual(builder.parentMode, .noParent)
+        XCTAssertEqual(builder.attributes["screen.name"]?.stringValue, "search_results")
+        XCTAssertEqual(builder.attributes["screen.tti.ms"]?.intValue, 800)
+        XCTAssertEqual(builder.attributes["screen.ttfr.ms"]?.intValue, 50)
+
+        let span = try XCTUnwrap(builder.startedSpan)
+        XCTAssertTrue(span.ended)
+    }
+
+    // MARK: - Fragment TTI
+
+    func testFragmentTTISpanUsesStringDescribingFallbackForNonRawRepresentable() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.fragmentTTIMetricsReceived(metrics: metrics(tti: 250), fragment: .header)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "fragment-tti.header",
+                       "Fallback to String(describing:) for non-String-backed RawRepresentable types")
+        XCTAssertEqual(builder.attributes["fragment.name"]?.stringValue, "header")
+        XCTAssertEqual(builder.attributes["fragment.tti.ms"]?.intValue, 250)
+        XCTAssertEqual(builder.attributes["fragment.ttfr.ms"]?.intValue, 50)
+    }
+
+    // MARK: - Screen rendering
+
+    func testScreenRenderingSpanCarriesRenderingAttributes() throws {
+        let provider = MockTracerProvider()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let instrumenter = makeInstrumenter(provider: provider, now: now)
+
+        instrumenter.renderingMetricsReceived(metrics: renderingMetrics(), screen: .homescreen)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "screen-rendering.homescreen")
+        XCTAssertEqual(builder.attributes["screen.name"]?.stringValue, "homescreen")
+        XCTAssertEqual(builder.attributes["rendering.total_frames"]?.intValue, 240)
+        XCTAssertEqual(builder.attributes["rendering.dropped_frames"]?.intValue, 5)
+        XCTAssertEqual(builder.attributes["rendering.slow_frames"]?.intValue, 7)
+        XCTAssertEqual(builder.attributes["rendering.freeze_time.ms"]?.intValue, 120)
+        XCTAssertEqual(builder.attributes["rendering.session_duration.ms"]?.intValue, 4_000)
+
+        let startTime = try XCTUnwrap(builder.startTime)
+        XCTAssertEqual(startTime.timeIntervalSince1970,
+                       now.addingTimeInterval(-4.0).timeIntervalSince1970,
+                       accuracy: 0.001,
+                       "Rendering span spans the session_duration ending now")
+    }
+
+    // MARK: - App rendering
+
+    func testAppRenderingSpanIsScreenless() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.appRenderingMetricsReceived(metrics: renderingMetrics(sessionMs: 2_000))
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "app-rendering")
+        XCTAssertNil(builder.attributes["screen.name"])
+        XCTAssertEqual(builder.attributes["rendering.session_duration.ms"]?.intValue, 2_000)
+    }
+
+    // MARK: - Hangs
+
+    func testFatalHangEmitsAppHangSpanWithFatalType() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+        let info = HangInfo.with(callStack: "stack", duringStartup: false, duration: .milliseconds(2_500))
+
+        instrumenter.fatalHangReceived(info: info)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "app-hang")
+        XCTAssertEqual(builder.attributes["hang.type"]?.stringValue, "fatal")
+        XCTAssertEqual(builder.attributes["hang.duration.ms"]?.intValue, 2_500)
+        XCTAssertEqual(builder.attributes["hang.during_startup"]?.boolValue, false)
+    }
+
+    func testNonFatalHangEmitsAppHangSpanWithNonFatalType() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+        let info = HangInfo.with(callStack: "stack", duringStartup: true, duration: .milliseconds(2_100))
+
+        instrumenter.nonFatalHangReceived(info: info)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "app-hang")
+        XCTAssertEqual(builder.attributes["hang.type"]?.stringValue, "non_fatal")
+        XCTAssertEqual(builder.attributes["hang.duration.ms"]?.intValue, 2_100)
+        XCTAssertEqual(builder.attributes["hang.during_startup"]?.boolValue, true)
+    }
+
+    func testHangStartedDoesNotEmitAnySpan() {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+        let info = HangInfo.with(callStack: "stack", duringStartup: false, duration: .milliseconds(2_000))
+
+        instrumenter.hangStarted(info: info)
+
+        XCTAssertTrue(
+            provider.tracer.builders.isEmpty,
+            "hangStarted is an in-progress signal; Phase 1 records nothing for it"
+        )
+    }
+
+    // MARK: - Watchdog termination
+
+    func testWatchdogTerminationEmitsPointSpanWithStateAndMemory() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+        let data = WatchdogTerminationData(
+            applicationState: .active,
+            appStartInfo: .empty,
+            duringStartup: false,
+            memoryWarnings: 4
+        )
+
+        instrumenter.watchdogTerminationReceived(data)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "app-watchdog-termination")
+        XCTAssertEqual(builder.attributes["app.state"]?.stringValue, "active")
+        XCTAssertEqual(builder.attributes["memory.warnings_count"]?.intValue, 4)
+        XCTAssertNotNil(builder.attributes["device.ram.mb"]?.intValue)
+
+        let span = try XCTUnwrap(builder.startedSpan)
+        XCTAssertEqual(span.firstEndTime, builder.startTime,
+                       "Watchdog termination is recorded as a zero-duration point in time")
+    }
+
+    // MARK: - Tracer provider resolution
+
+    func testTracerProviderReceivesInstrumentationNameAndVersion() {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.startupTimeReceived(startupData(prewarmed: false))
+
+        XCTAssertEqual(provider.getCalls.count, 1)
+        XCTAssertEqual(provider.getCalls.first?.instrumentationName, "perfsuite-ios")
+        XCTAssertEqual(provider.getCalls.first?.instrumentationVersion, "1.7.0")
+    }
+
+    func testTracerProviderResolutionIsLazyAcrossEmissions() {
+        // The emitter is meant to *re-resolve* the global provider every call so
+        // that a late-registered SDK still wins. We verify by emitting twice
+        // and asserting two `get` calls reach the provider.
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        instrumenter.startupTimeReceived(startupData(prewarmed: false))
+        instrumenter.appRenderingMetricsReceived(metrics: renderingMetrics())
+
+        XCTAssertEqual(provider.getCalls.count, 2,
+                       "Each emit should resolve the provider, not cache the tracer at init time")
+    }
+
+    // MARK: - screenIdentifier(for:)
+
+    func testScreenIdentifierForViewControllerScreenUsesMainBundleDefault() {
+        // When Screen == UIViewController and no closure is provided, the
+        // instrumenter mirrors PerformanceSuite's default of tracking only
+        // main-bundle view controllers.
+        let instrumenter = OTelInstrumenter<UIViewController, String>()
+
+        // System UIViewController is in UIKit's bundle, not the main bundle.
+        XCTAssertNil(instrumenter.screenIdentifier(for: UIViewController()))
+    }
+
+    func testScreenIdentifierForGenericScreenWithoutClosureReturnsNil() {
+        let instrumenter = OTelInstrumenter<TestScreen, TestFragment>()
+
+        XCTAssertNil(
+            instrumenter.screenIdentifier(for: UIViewController()),
+            "Without a closure, a typed Screen has no way to map a VC and must return nil"
+        )
+    }
+
+    func testScreenIdentifierUsesProvidedClosure() {
+        let provider = MockTracerProvider()
+        let viewController = UIViewController()
+        var captured: UIViewController?
+        let instrumenter = OTelInstrumenter<TestScreen, TestFragment>(
+            screenIdentifier: { vc in
+                captured = vc
+                return .homescreen
+            },
+            tracerProvider: provider
+        )
+
+        let mapped = instrumenter.screenIdentifier(for: viewController)
+
+        XCTAssertEqual(mapped, .homescreen)
+        XCTAssertTrue(captured === viewController)
+    }
+}

--- a/PerformanceSuite/OTel/Tests/OTelInstrumenterTests.swift
+++ b/PerformanceSuite/OTel/Tests/OTelInstrumenterTests.swift
@@ -125,7 +125,7 @@ final class OTelInstrumenterTests: XCTestCase {
         let builder = try XCTUnwrap(provider.tracer.lastBuilder)
         XCTAssertEqual(
             builder.attributes["app.startup.prewarmed"]?.boolValue, true,
-            "OTel side always emits, including for prewarmed launches (RFC §11 F-12)"
+            "OTel side always emits, including for prewarmed launches"
         )
     }
 

--- a/PerformanceSuite/OTel/Tests/OTelSpanNamePrefixTests.swift
+++ b/PerformanceSuite/OTel/Tests/OTelSpanNamePrefixTests.swift
@@ -1,0 +1,96 @@
+//
+//  OTelSpanNamePrefixTests.swift
+//  PerformanceSuiteOTel-Tests
+//
+//  Created by Ahmed Nafei on 01/05/2026.
+//
+
+import OpenTelemetryApi
+@testable import PerformanceSuite
+import UIKit
+import XCTest
+
+#if canImport(PerformanceSuiteOTel)
+@testable import PerformanceSuiteOTel
+#endif
+
+private enum TestScreen: String {
+    case homescreen
+    case searchResults = "search_results"
+}
+
+private enum TestFragment: Equatable {
+    case header
+}
+
+final class OTelSpanNamePrefixTests: XCTestCase {
+
+    private func makePrefixedInstrumenter(
+        provider: MockTracerProvider,
+        prefix: String?
+    ) -> OTelInstrumenter<TestScreen, TestFragment> {
+        OTelInstrumenter<TestScreen, TestFragment>(
+            screenIdentifier: nil,
+            tracerProvider: provider,
+            instrumentationName: "perfsuite-ios",
+            instrumentationVersion: "1.7.0",
+            spanNamePrefix: prefix,
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    func testPrefixIsAppliedToAllSpanTypes() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makePrefixedInstrumenter(provider: provider, prefix: "bookingcom")
+
+        let startup = StartupTimeData(
+            totalTime: .milliseconds(1_500), preMainTime: .milliseconds(300),
+            mainTime: .milliseconds(1_200), totalBeforeViewControllerTime: .milliseconds(900),
+            mainBeforeViewControllerTime: .milliseconds(600),
+            appStartInfo: AppStartInfo(appStartedWithPrewarming: false)
+        )
+        instrumenter.startupTimeReceived(startup)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.app-startup")
+
+        let tti = TTIMetrics(tti: .milliseconds(800), ttfr: .milliseconds(50), appStartInfo: .empty)
+        instrumenter.ttiMetricsReceived(metrics: tti, screen: .searchResults)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.screen-tti.search_results")
+
+        instrumenter.fragmentTTIMetricsReceived(metrics: tti, fragment: .header)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.fragment-tti.header")
+
+        let rendering = RenderingMetrics(
+            renderedFrames: 240, expectedFrames: 240, droppedFrames: 5,
+            frozenFrames: 0, slowFrames: 7, freezeTime: .milliseconds(120),
+            sessionDuration: .milliseconds(4_000), appStartInfo: .empty
+        )
+        instrumenter.renderingMetricsReceived(metrics: rendering, screen: .homescreen)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.screen-rendering.homescreen")
+
+        instrumenter.appRenderingMetricsReceived(metrics: rendering)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.app-rendering")
+
+        let hangInfo = HangInfo.with(callStack: "stack", duringStartup: false, duration: .milliseconds(2_500))
+        instrumenter.fatalHangReceived(info: hangInfo)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.app-hang")
+
+        let wtData = WatchdogTerminationData(
+            applicationState: .active, appStartInfo: .empty,
+            duringStartup: false, memoryWarnings: 1
+        )
+        instrumenter.watchdogTerminationReceived(wtData)
+        XCTAssertEqual(provider.tracer.builders.last?.spanName, "bookingcom.app-watchdog-termination")
+    }
+
+    func testNilPrefixEmitsUnprefixedSpanNames() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makePrefixedInstrumenter(provider: provider, prefix: nil)
+
+        let tti = TTIMetrics(tti: .milliseconds(800), ttfr: .milliseconds(50), appStartInfo: .empty)
+        instrumenter.ttiMetricsReceived(metrics: tti, screen: .searchResults)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        XCTAssertEqual(builder.spanName, "screen-tti.search_results",
+                       "nil prefix must not add a dot or empty segment")
+    }
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,17 +53,22 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - OpenTelemetry-Swift-Api (2.3.0)
   - PerformanceSuite (1.6.0):
     - PerformanceSuite/Core (= 1.6.0)
   - PerformanceSuite/Core (1.6.0)
   - PerformanceSuite/Crashlytics (1.6.0):
     - FirebaseCrashlytics
     - PerformanceSuite/Core
+  - PerformanceSuite/OTel (1.6.0):
+    - OpenTelemetry-Swift-Api (~> 2.0)
+    - PerformanceSuite/Core
   - PerformanceSuite/PerformanceApp (1.6.0):
     - GCDWebServer
     - PerformanceSuite/Crashlytics
   - PerformanceSuite/Tests (1.6.0):
     - PerformanceSuite/Crashlytics
+    - PerformanceSuite/OTel
   - PerformanceSuite/UITests (1.6.0):
     - GCDWebServer
     - PerformanceSuite/PerformanceApp
@@ -92,6 +97,7 @@ SPEC REPOS:
     - GoogleDataTransport
     - GoogleUtilities
     - nanopb
+    - OpenTelemetry-Swift-Api
     - PromisesObjC
     - PromisesSwift
     - SwiftLint
@@ -112,7 +118,8 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  PerformanceSuite: cb72bf1094741f6c9f6676d41dd6e01779eecd92
+  OpenTelemetry-Swift-Api: 3d77582ab6837a63b65bf7d2eacc57d8f2595edd
+  PerformanceSuite: 3cdca936c460e3f90b30903b7c177726bbcbfbd6
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   SwiftLint: 4fa4a9b437ccc4fc72f6c0bc98556e8e9e05bccf


### PR DESCRIPTION
Introduces a new open-source library that turns every PerformanceSuite metric into an OpenTelemetry span, so consumers can route performance data through any OTel-compatible backend (Embrace dashboards, OTLP collectors, custom pipelines) without writing their own bridge.

The library lives under the existing perfsuite-ios repo following the PerformanceSuiteCrashlytics precedent: same repo, same release cycle, same tag - two libraries shipped from one PR.

New types

  OTelInstrumenter<Screen, Fragment>
      Public adapter conforming to all seven PerformanceSuite receiver
      protocols. Generic over the host app's screen / fragment
      identifier types so it can be used standalone (OTel-only) or
      wrapped inside Multi*Receivers from PerformanceSuite core for
      dual-emit setups.

  OTelSpanEmitter
      Internal helper that builds one OTel span per metric. Lazily
      resolves OpenTelemetry.instance.tracerProvider on every emit, so
      that an OTel SDK that registers its provider after PerformanceSuite
      has started (typical when Embrace.setup() runs alongside
      PerformanceMonitoring.enable()) still receives the spans.

  OTelSemanticConventions
      Public namespace of stable constants for span names and attribute
      keys. Backend dashboards can target these without grepping the
      source.

Module compatibility

OTel sources use the same dual-mode import pattern as Crashlytics:

    #if canImport(PerformanceSuiteOTel)
    import PerformanceSuite
    #endif

In SwiftPM PerformanceSuiteOTel is a separate module and the explicit import is needed. In CocoaPods all subspec sources land in the single PerformanceSuite framework, so the same line would be a self-import and is correctly skipped.