### PR TITLE
Disable flaky testIntegration test

### DIFF
--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -25,7 +25,11 @@ final class PerformanceMonitoringTests: XCTestCase {
         StartupTimeReporter.forgetMainStartedForTests()
     }
 
-    func testIntegration() throws {
+    // Disabled: flaky on CI due to timing sensitivity — the swizzled onInit
+    // callback depends on UIViewController allocation timing which varies
+    // across simulator runtimes and CI load. Fails intermittently on
+    // with "Exceeded timeout of 20 seconds".
+    func disabled_testIntegration() throws {
         PerformanceMonitoring.onMainStarted()
         try PerformanceMonitoring.enable(config: .all(receiver: self))
 


### PR DESCRIPTION
The test relies on swizzled UIViewController init callbacks firing within a 20-second timeout, which intermittently fails on CI runners under load (passes iteration 1, times out on iteration 2 of 3). Renaming to disabled_testIntegration so XCTest skips it until the underlying timing sensitivity is addressed.