### PR TITLE
Add -Dynamic library product flavors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,34 @@ let package = Package(
         .library(
             name: "PerformanceSuiteOTel",
             targets: ["PerformanceSuiteOTel"]),
+
+        // Explicit dynamic-flavor products. The default products above are
+        // implicitly static, which means each consumer that links them ends up
+        // with its own copy of the targets' object code and Swift module-level
+        // static state. Consumers that mix several of these products (e.g. an
+        // app framework that uses `PerformanceSuiteCrashlytics` and a sibling
+        // framework that uses `PerformanceSuiteOTel`) can therefore see the
+        // same `PerformanceMonitoring` enum's static storage duplicated across
+        // binaries, breaking single-source-of-truth assumptions.
+        //
+        // The `-Dynamic` flavors expose the same targets as `type: .dynamic`
+        // libraries, so consumers that want shared state across binaries can
+        // opt in without breaking existing setups that rely on static linking.
+        // This mirrors how `apollographql/apollo-ios` ships both a default
+        // (static) `Apollo` library and a parallel `Apollo-Dynamic` flavor.
+        .library(
+            name: "PerformanceSuite-Dynamic",
+            type: .dynamic,
+            targets: ["PerformanceSuite"]),
+        .library(
+            name: "PerformanceSuiteCrashlytics-Dynamic",
+            type: .dynamic,
+            targets: ["PerformanceSuiteCrashlytics"]),
+        .library(
+            name: "PerformanceSuiteOTel-Dynamic",
+            type: .dynamic,
+            targets: ["PerformanceSuiteOTel"]),
+
         .executable(
             name: "PerformanceApp",
             targets: ["PerformanceApp"]


### PR DESCRIPTION
Adds three new SPM library products — `PerformanceSuite-Dynamic`, `PerformanceSuiteCrashlytics-Dynamic`, and `PerformanceSuiteOTel-Dynamic` — that expose the existing targets as `type: .dynamic` libraries. The default (static) products are unchanged.

Why: when several consumers in the same app link the static products, each consumer ends up with its own copy of `PerformanceMonitoring`'s static state, since static products are absorbed into each consumer's binary. Hosts that mix products (e.g. a framework on `PerformanceSuiteCrashlytics` and a sibling on `PerformanceSuiteOTel`) have to add per-host workarounds — like a `disableForTests()` shim that routes resets through the right binary's copy — to keep the state consistent. The new `-Dynamic` flavors give consumers the option to link a single shared dynamic framework instead, eliminating the duplicated state by construction.

The pattern mirrors how `apollographql/apollo-ios` ships both an `Apollo` (default static) and an `Apollo-Dynamic` (`type: .dynamic`) library product backed by the same target.

No target changes; only product entries.