### PR TITLE
Re-enable testIntegration and make it more stable

### DIFF
--- a/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
+++ b/PerformanceSuite/Tests/PerformanceMonitoringTests.swift
@@ -25,22 +25,18 @@ final class PerformanceMonitoringTests: XCTestCase {
         StartupTimeReporter.forgetMainStartedForTests()
     }
 
-    // Disabled: flaky on CI due to timing sensitivity — the swizzled onInit
-    // callback depends on UIViewController allocation timing which varies
-    // across simulator runtimes and CI load. Fails intermittently on
-    // with "Exceeded timeout of 20 seconds".
-    func disabled_testIntegration() throws {
+    func testIntegration() throws {
         PerformanceMonitoring.onMainStarted()
         try PerformanceMonitoring.enable(config: .all(receiver: self))
 
-        let exp = expectation(description: "onInit")
-        onInitExpectation = exp
-        let vc = UIViewController()
-        wait(for: [exp], timeout: 20) // increase timeout as it is very slow on CI
-        _ = vc
+        var onInitCalled = false
+        onInitHandler = { onInitCalled = true }
 
-        // simulate vc appearance to generate more performance events
-        // checking there are no crashes
+        let vc = UIViewController()
+        PerformanceMonitoring.queue.sync { }
+        PerformanceMonitoring.consumerQueue.sync { }
+        XCTAssertTrue(onInitCalled)
+
         _ = vc.view
         vc.beginAppearanceTransition(true, animated: false)
         vc.endAppearanceTransition()
@@ -53,15 +49,14 @@ final class PerformanceMonitoringTests: XCTestCase {
 
         try PerformanceMonitoring.disable()
 
-        let exp2 = expectation(description: "onInit2")
-        exp2.isInverted = true
-        onInitExpectation = exp2
+        onInitCalled = false
         let vc2 = UIViewController()
-        wait(for: [exp2], timeout: 5)
+        PerformanceMonitoring.queue.sync { }
+        PerformanceMonitoring.consumerQueue.sync { }
+        XCTAssertFalse(onInitCalled)
         _ = vc2
 
-        let appStartInfo = PerformanceMonitoring.appStartInfo
-        XCTAssertFalse(appStartInfo.appStartedWithPrewarming)
+        XCTAssertFalse(PerformanceMonitoring.appStartInfo.appStartedWithPrewarming)
     }
 
     func testPrewarming() throws {
@@ -122,7 +117,7 @@ final class PerformanceMonitoringTests: XCTestCase {
         return "hang_type"
     }
 
-    private var onInitExpectation: XCTestExpectation?
+    private var onInitHandler: (() -> Void)?
 }
 
 extension PerformanceMonitoringTests: PerformanceSuiteMetricsReceiver {
@@ -164,7 +159,7 @@ extension PerformanceMonitoringTests: PerformanceSuiteMetricsReceiver {
     }
 
     func onInit(screen: String) {
-        onInitExpectation?.fulfill()
+        onInitHandler?()
     }
 
     func onViewDidLoad(screen: String) {


### PR DESCRIPTION
## Summary

Re-enables `PerformanceMonitoringTests.testIntegration`, which was disabled in 0626995 due to a 20-second timeout flake on CI.

**Root cause.** The test waited for `onInit` via an `XCTestExpectation`. The delivery chain hops main → `PerformanceMonitoring.queue` (`.userInteractive`) → `consumerQueue` (`.background`) → receiver. Under load, the OS throttles `.background` QoS dispatches; the wait time is therefore probabilistic, not deterministic. Locally I reproduced this by running the test in-process under CPU stress (32× `yes`, load avg ~50): one iteration spent **17.7 s** on the first onInit (vs. ~5 s baseline), well within the variance that pushes a slower CI runner past 20 s.

**Fix.** Replace `wait(for: [exp], timeout: 20)` (and the inverted 5 s wait) with sync drains of the two queues, then a flag assertion. `dispatch_sync` blocks until all already-enqueued blocks finish, regardless of QoS throttling, so the test becomes deterministic. Same swizzler → queue → consumerQueue → receiver path is exercised; what's removed is the wall-clock dependency.

## Verification

In-process iteration sweep (`-test-iterations 30 -run-tests-until-failure`) with the same 32-yes CPU stress applied:

| | original test | this PR |
|---|---|---|
| stressed iter 3 | **17.7 s** | 0.002 s |
| stressed iter 8 | 7.85 s | 0.002 s |
| stressed worst (of 30) | timeout-prone | 0.903 s |
| 30 iters total wall-clock | aborted early | **33 s** |

## Test plan

- [ ] CI Unit Tests pass
- [ ] No regressions in adjacent `PerformanceMonitoringTests` (testPrewarming / testNoPrewarming / testEnableWithCrashlytics / testEnableWithDisabledCrashlytics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)