### PR TITLE
Fix testAppFreezeTime + drop ineffective ui-tests matrix split

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           set -e
           echo "Starting UI tests with destination: $destination, suite: $suite"
-          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UITestResults.xcresult -only-testing:"PerformanceSuite-UI-UITests/$suite"
+          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UITestResults.xcresult -only-testing:"PerformanceSuite-UI-UITests/$suite" SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'
           echo "UI tests completed successfully"
 
       - name: Save DerivedData

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,10 +161,6 @@ jobs:
 
   ui-tests:
     runs-on: macos-26
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: [TerminationTests, MetricsTests]
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -193,21 +189,20 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: DerivedData
-          key: ${{ runner.os }}-deriveddata-ui-${{ matrix.suite }}-${{ hashFiles('Podfile.lock') }}
+          key: ${{ runner.os }}-deriveddata-ui-${{ hashFiles('Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-deriveddata-ui-${{ matrix.suite }}-
+            ${{ runner.os }}-deriveddata-ui-
 
       - name: Run UI Tests
         env:
           scheme: UITests
           destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
           workspace: Project.xcworkspace
-          suite: ${{ matrix.suite }}
         timeout-minutes: 30
         run: |
           set -e
-          echo "Starting UI tests with destination: $destination, suite: $suite"
-          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UITestResults.xcresult -only-testing:"PerformanceSuite-UI-UITests/$suite" SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'
+          echo "Starting UI tests with destination: $destination"
+          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UITestResults.xcresult SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'
           echo "UI tests completed successfully"
 
       - name: Save DerivedData
@@ -215,13 +210,13 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: DerivedData
-          key: ${{ runner.os }}-deriveddata-ui-${{ matrix.suite }}-${{ hashFiles('Podfile.lock') }}
+          key: ${{ runner.os }}-deriveddata-ui-${{ hashFiles('Podfile.lock') }}
 
       - name: Upload UI Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ui-test-results-${{ matrix.suite }}
+          name: ui-test-results
           path: UITestResults.xcresult
           retention-days: 30
 

--- a/PerformanceSuite/UITests/BaseTests.swift
+++ b/PerformanceSuite/UITests/BaseTests.swift
@@ -50,16 +50,26 @@ class BaseTests: XCTestCase {
     }
 
     func waitForMessage(_ checker: @escaping (Message) -> Bool) {
-        let exp = expectation(description: "wait for message")
+        waitForCondition { [weak self] in
+            self?.client.messages.contains(where: checker) ?? false
+        }
+    }
+
+    /// Polls `check` every 0.1s up to the timeout, fulfilling when it returns
+    /// true. Useful when the success condition is a function of all received
+    /// messages (e.g. an accumulated total) rather than the presence of a
+    /// single message.
+    func waitForCondition(timeout: TimeInterval = 180, _ check: @escaping () -> Bool) {
+        let exp = expectation(description: "wait for condition")
         var fired = false
-        waitingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            guard let self = self, !fired else { return }
-            if self.client.messages.contains(where: checker) {
+        waitingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+            guard !fired else { return }
+            if check() {
                 exp.fulfill()
                 fired = true
             }
         }
 
-        wait(for: [exp], timeout: 180)
+        wait(for: [exp], timeout: timeout)
     }
 }

--- a/PerformanceSuite/UITests/MetricsTests.swift
+++ b/PerformanceSuite/UITests/MetricsTests.swift
@@ -76,11 +76,17 @@ class MetricsTests: BaseTests {
         assertNoMessages(aftMessage)
 
         app.staticTexts["Freeze Time"].tap()
-        waitForMessage { $0 == aftMessage }
 
-        let foundMessage = try XCTUnwrap(client.messages.first(where: { $0 == aftMessage }))
-        if case .appFreezeTime(let duration) = foundMessage {
-            XCTAssertGreaterThan(duration, 2000)
+        // The throttle in AppRenderingReporter may emit several short reports
+        // while the freeze unfolds (especially under a smaller throttle in
+        // tests), so wait for the *accumulated* freeze time across all
+        // appFreezeTime messages to exceed our 2s threshold.
+        waitForCondition {
+            let total = self.client.messages.reduce(0) { acc, msg in
+                if case .appFreezeTime(let duration) = msg { return acc + duration }
+                return acc
+            }
+            return total > 2000
         }
     }
 }


### PR DESCRIPTION
## Summary

Two related changes to make the UI test pipeline reliable and cheap:

### 1. `testAppFreezeTime` accumulates freeze time across reports

The test asserted that the *first* received `appFreezeTime` message had `duration > 2000ms`. That implicitly required a long throttle (default 5s) so all freeze drops would land in a single emit. The downside: with the throttle that long, sustained drops on slow CI can keep the emit deferred indefinitely (cancel-and-reschedule on every drop) and the test times out waiting for any message.

The test now sums `duration` across all received `appFreezeTime` messages and asserts the total > 2000ms. The reporter is free to chunk the freeze into multiple short emits, the test just checks the total.

That unblocks shrinking the throttle in tests, which we now do via the existing `#if PERFORMANCE_TESTS` block in `PerformanceMonitoring.swift` (0.3s throttle in tests, default 5s in production). The flag is defined for the UI-test `xcodebuild` invocation by passing `SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'` from CI. Only one place in the codebase references the flag, so the blast radius is exactly the throttle interval.

### 2. Drop the ui-tests matrix split

Earlier work split `ui-tests` into a 2-job matrix (`TerminationTests`, `MetricsTests`) on the assumption that two jobs in parallel would beat one sequential job. Measured wall-clock says otherwise:

| Setup | Wall |
|---|---|
| Matrix split (2 parallel runners) | 12m26s |
| Single job (this PR) | 11m46s |

The split's parallelism gain is canceled by the per-runner overhead — each `macos-26` runner has to allocate, install Pods, restore DerivedData, boot a fresh simulator. With `TerminationTests` ~12 min and `MetricsTests` ~9 min, the wall floor of the split is `max(slow_job) + setup ≈ sequential time`. Single job is actually slightly faster and obviously simpler.

Removing the matrix means a single ui-tests job with one DerivedData cache slot, no `-only-testing` filter, no per-suite artifact name.

## Changes

- **`MetricsTests.swift`** — `testAppFreezeTime` accumulates `duration` across all received `appFreezeTime` messages, asserts the total > 2000ms.
- **`BaseTests.swift`** — adds a `waitForCondition` helper (polls a predicate every 0.1s up to a timeout). `waitForMessage` rewritten on top of it.
- **`.github/workflows/tests.yml`** —
  - Drops the `strategy.matrix` from the `ui-tests` job.
  - Drops `-only-testing:` and the `${{ matrix.suite }}` references in cache key, artifact name, and shell vars.
  - Adds `SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'` to the UI-test `xcodebuild` invocation, activating the test-mode throttle override.

## Test plan
- [x] `testAppFreezeTime` passes locally with default 5s throttle (~15s wall-clock)
- [x] `testAppFreezeTime` passes locally with `SWIFT_ACTIVE_COMPILATION_CONDITIONS=PERFORMANCE_TESTS` (0.3s throttle, ~9s wall-clock)
- [x] CI run on this branch: all 11 UI tests pass first iteration (no `retryOnFailure` kick-in), single job total **11m46s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)