### PR TITLE
Run UI test classes in parallel via job-level matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,10 @@ jobs:
 
   ui-tests:
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [TerminationTests, MetricsTests]
     steps:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -115,24 +119,25 @@ jobs:
       - name: Install CocoaPods
         run: |
           pod install
-          
+
       - name: Run UI Tests
         env:
           scheme: UITests
           destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
           workspace: Project.xcworkspace
+          suite: ${{ matrix.suite }}
         timeout-minutes: 30
         run: |
           set -e
-          echo "Starting UI tests with destination: $destination"
-          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -resultBundlePath UITestResults.xcresult
+          echo "Starting UI tests with destination: $destination, suite: $suite"
+          xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -resultBundlePath UITestResults.xcresult -only-testing:"PerformanceSuite-UI-UITests/$suite"
           echo "UI tests completed successfully"
-      
+
       - name: Upload UI Test Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ui-test-results
+          name: ui-test-results-${{ matrix.suite }}
           path: UITestResults.xcresult
           retention-days: 30
 

--- a/PerformanceSuite/UITests/BaseTests.swift
+++ b/PerformanceSuite/UITests/BaseTests.swift
@@ -60,6 +60,6 @@ class BaseTests: XCTestCase {
             }
         }
 
-        wait(for: [exp], timeout: 60)
+        wait(for: [exp], timeout: 180)
     }
 }


### PR DESCRIPTION
## Summary

Splits the single `ui-tests` job into two parallel jobs (one runner each) via matrix strategy: `TerminationTests` and `MetricsTests`. `xcodebuild` gets `-only-testing:PerformanceSuite-UI-UITests/<suite>` so each runner runs just its assigned class.

### Why job-level, not Xcode `-parallel-testing-enabled`

- `-parallel-testing-enabled` clones the simulator, but the clones share the host's loopback. Earlier in-job parallel attempts had cloned simulators fighting over the interop server's hardcoded port (`localhost:50001`) — first wins, others fail to bind.
- The `macos-26` standard runner is 3 cores / 7 GB. Two iOS simulator clones together thrash the runner: tests run 4-12× slower under that load and the 30-min step timeout fires.
- With matrix, each runner is its own VM. No shared loopback, no resource contention. Each runner runs one suite serially, suites run on separate runners in parallel.

### Wall-time impact

- Sequential ui-tests on main: ~7m of test execution + build, total job ~12–13m.
- Matrix split: each suite is ~4–7m. Wall-clock is bounded by the slower job (typically `TerminationTests`, which has the slow `testStartupFatalHang` test).

### Also in this PR

- Bumps `waitForMessage` 60s → 180s. The `macos-26` simulator is several times slower than a developer Mac; 60s was too tight for `testStartupFatalHang`'s three sequential launches (~90s on CI). 180s gives headroom without inflating green-path runs.
- Artifact name now includes the suite (`ui-test-results-<suite>`) so both runners' xcresult bundles upload without colliding.

## Test plan
- [x] Both matrix subjobs (`ui-tests (TerminationTests)`, `ui-tests (MetricsTests)`) appear in the GitHub Actions UI as separate parallel jobs
- [x] `-only-testing` correctly scopes each runner to its assigned class (verified by counting test cases in each job's log)
- [x] Wall-clock time of the `ui-tests` step is bounded by the slower suite (TerminationTests), not the sum of both

🤖 Generated with [Claude Code](https://claude.com/claude-code)