### PR TITLE
End app-rendering and screen-rendering live spans on willResignActive 

### DIFF
--- a/PerformanceSuite.podspec
+++ b/PerformanceSuite.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                 = 'PerformanceSuite'
-  s.version              = '1.10.1'
+  s.version              = '1.10.0'
   s.summary              = 'Performance monitoring library for iOS'
   s.homepage             = 'https://github.com/bookingcom/perfsuite-ios' 
   s.license              = { :type => 'MIT', :file => 'LICENSE' }

--- a/PerformanceSuite.podspec
+++ b/PerformanceSuite.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                 = 'PerformanceSuite'
-  s.version              = '1.10.0'
+  s.version              = '1.10.1'
   s.summary              = 'Performance monitoring library for iOS'
   s.homepage             = 'https://github.com/bookingcom/perfsuite-ios' 
   s.license              = { :type => 'MIT', :file => 'LICENSE' }

--- a/PerformanceSuite/Sources/InstanceObservers/RenderingObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/RenderingObserver.swift
@@ -17,6 +17,7 @@ final class RenderingObserver<R: RenderingMetricsReceiver>: ViewControllerInstan
         self.screen = screen
         self.metricsReceiver = metricsReceiver
         self.framesMeter = framesMeter
+        registerAppLifecycleObservers()
     }
 
     private let screen: R.ScreenIdentifier
@@ -36,6 +37,14 @@ final class RenderingObserver<R: RenderingMetricsReceiver>: ViewControllerInstan
     /// queued before didAppear's. Set/read only on PerformanceMonitoring.queue.
     private var didAppearProcessed = false
     private var pendingDisappear = false
+
+    /// True while the live span was ended early by app backgrounding (willResignActive) but the screen
+    /// is still on-screen — so didBecomeActive restarts a fresh span and a later real viewWillDisappear
+    /// must not double-report. Set/read only on PerformanceMonitoring.queue.
+    private var endedForBackground = false
+    /// Block-based app-lifecycle observers (RenderingObserver is generic, so it can't expose @objc
+    /// selectors). Removed in deinit.
+    private var lifecycleObservers: [any NSObjectProtocol] = []
 
     func beforeInit() {}
 
@@ -86,13 +95,76 @@ final class RenderingObserver<R: RenderingMetricsReceiver>: ViewControllerInstan
 
     private func processDisappear() {
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
-        framesMeter.unsubscribe(receiver: self)
-        reportMetricsIfNeeded()
+        // If the span was already ended early by backgrounding (and not restarted) it is finished and
+        // already unsubscribed — must not unsubscribe or report again. Otherwise this is a normal
+        // disappear: unsubscribe the FramesMeter, report, and end the live span.
+        if !endedForBackground {
+            framesMeter.unsubscribe(receiver: self)
+            reportMetricsIfNeeded()
+        }
         // Reset the latch + counters so a reused VC instance starts a clean session next appearance.
         // Without this, a second sync push-then-pop runs the disappear before the re-appear setup —
         // re-dispatching stale metrics to a legacy receiver and orphaning the new live measurement.
         didAppearProcessed = false
+        endedForBackground = false
         metrics = .zero
+    }
+
+    // MARK: - App lifecycle (background-safe live span)
+
+    /// Screen-rendering spans run from viewDidAppear to viewWillDisappear, which can straddle an app
+    /// background. Backgrounding fires no viewWillDisappear, so the open span would otherwise be
+    /// auto-terminated by the backend (e.g. Embrace, `user_abandon`). End it synchronously on
+    /// willResignActive — which precedes the backend's didEnterBackground session-end — and restart it
+    /// on didBecomeActive while the screen is still visible. Mirrors AppRenderingReporter's handling.
+    private func registerAppLifecycleObservers() {
+        let resign = NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification, object: nil, queue: nil
+        ) { [weak self] _ in self?.handleWillResignActive() }
+        let active = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil
+        ) { [weak self] _ in self?.handleDidBecomeActive() }
+        lifecycleObservers = [resign, active]
+    }
+
+    private func handleWillResignActive() {
+        // Synchronous so the live span ends within this notification turn — before the backend ends
+        // the session on didEnterBackground and auto-terminates the still-open span.
+        PerformanceMonitoring.runOnQueue {
+            self.endForBackground()
+        }
+    }
+
+    private func endForBackground() {
+        dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
+        guard didAppearProcessed, let context = measurementHandle, !endedForBackground else { return }
+        framesMeter.unsubscribe(receiver: self)
+        let metrics = self.metrics
+        self.measurementHandle = nil
+        self.endedForBackground = true
+        // Synchronous finalize to win the race against the backend's session-end auto-termination.
+        PerformanceMonitoring.consumerQueue.sync {
+            if #available(iOS 16.0, *), let live = self.metricsReceiver as? any LiveRenderingMetricsReceiver<R.ScreenIdentifier> {
+                live.screenRenderingEnded(metrics: metrics, screen: self.screen, context: context)
+            } else {
+                self.metricsReceiver.renderingMetricsReceived(metrics: metrics, screen: self.screen)
+            }
+        }
+    }
+
+    private func handleDidBecomeActive() {
+        // Capture the wall-clock anchor synchronously before the queue hop (same as afterViewDidAppear).
+        let sessionStarted = Date()
+        PerformanceMonitoring.queue.async {
+            // Only restart if we ended early for background AND the screen is still appeared.
+            guard self.endedForBackground, self.didAppearProcessed else { return }
+            self.endedForBackground = false
+            self.metrics = RenderingMetrics.zero(sessionStarted: sessionStarted)
+            self.framesMeter.subscribe(receiver: self)
+            if #available(iOS 16.0, *), let live = self.metricsReceiver as? any LiveRenderingMetricsReceiver<R.ScreenIdentifier> {
+                self.measurementHandle = live.screenRenderingStarted(screen: self.screen, sessionStarted: sessionStarted)
+            }
+        }
     }
 
     private func reportMetricsIfNeeded() {
@@ -132,6 +204,7 @@ final class RenderingObserver<R: RenderingMetricsReceiver>: ViewControllerInstan
         // Observer destroyed before viewWillDisappear (e.g. VC popped without UIKit
         // delivering the willDisappear lifecycle, or a stand-alone observer scope).
         // Discard any live measurement so it never leaks as half-finished. Idempotent.
+        lifecycleObservers.forEach { NotificationCenter.default.removeObserver($0) }
         self.measurementHandle?.cancel()
     }
 }

--- a/PerformanceSuite/Sources/Reporters/AppRenderingReporter.swift
+++ b/PerformanceSuite/Sources/Reporters/AppRenderingReporter.swift
@@ -58,6 +58,16 @@ final class AppRenderingReporter: FramesMeterReceiver, AppMetricsReporter {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+        // Ends the live span on willResignActive — which fires BEFORE didEnterBackground, hence
+        // before Embrace's didEnterBackground-driven SessionController.endSession() →
+        // autoTerminateSpans(). Ending synchronously here lets our clean end win that race so the
+        // span ships Status.unset + real duration instead of being auto-terminated (user_abandon).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(appDidEnterBackground),
@@ -113,7 +123,7 @@ final class AppRenderingReporter: FramesMeterReceiver, AppMetricsReporter {
     /// finish before the process dies); `didEnterBackground` is async to keep the transition off main
     /// and avoid a `main → PM.queue → consumerQueue → main` deadlock. A finalize that misses
     /// suspension is covered by the caller-injected auto-termination attribute.
-    private func drainAndEndSession(synchronously: Bool) {
+    private func drainAndEndSession(synchronously: Bool, completion: (() -> Void)? = nil) {
         PerformanceMonitoring.runOnQueue {
             self.scheduledSending?.cancel()
             self.scheduledSending = nil
@@ -124,6 +134,7 @@ final class AppRenderingReporter: FramesMeterReceiver, AppMetricsReporter {
                     self.metricsReceiver.appRenderingMetricsReceived(metrics: metrics)
                 }
                 (self.metricsReceiver as? LiveAppRenderingMetricsReceiver)?.appRenderingSessionEnded()
+                completion?()
             }
             if synchronously {
                 PerformanceMonitoring.consumerQueue.sync(execute: deliver)
@@ -141,8 +152,39 @@ final class AppRenderingReporter: FramesMeterReceiver, AppMetricsReporter {
         }
     }
 
+    @objc private func appWillResignActive() {
+        // Synchronous end so it completes within this notification turn — before Embrace ends the
+        // session on didEnterBackground. Idempotent: if the app merely resigns active for a transient
+        // interruption (Control Center / notification / call) and returns without backgrounding, the
+        // next didBecomeActive starts a fresh session span. The auto-termination attribute remains the
+        // safety net for unclean exits where willResignActive never fires (jetsam/OOM/crash while active).
+        drainAndEndSession(synchronously: true)
+    }
+
     @objc private func appDidEnterBackground() {
-        drainAndEndSession(synchronously: false)
+        // Hold a background-task assertion across the async finalize so `span.end()`
+        // actually runs before the process is suspended. Without it the
+        // `consumerQueue.async` finalize loses the race with suspension on essentially
+        // every backgrounding: the span stays open and is closed only by the backend's
+        // auto-termination on the NEXT launch (bogus duration, `emb.error_code=user_abandon`,
+        // and none of the `finalizeAppRenderingLiveSpan` attributes). Kept async (not `sync`)
+        // on purpose — a synchronous `consumerQueue.sync` from main can deadlock if a
+        // span-processor `onEnd` ever hops back to main; the background task gives the
+        // existing async path the runtime it needs instead.
+        let application = UIApplication.shared
+        var backgroundTask: UIBackgroundTaskIdentifier = .invalid
+        backgroundTask = application.beginBackgroundTask(withName: "perfsuite.app-rendering.finalize") {
+            if backgroundTask != .invalid {
+                application.endBackgroundTask(backgroundTask)
+                backgroundTask = .invalid
+            }
+        }
+        drainAndEndSession(synchronously: false) {
+            if backgroundTask != .invalid {
+                application.endBackgroundTask(backgroundTask)
+                backgroundTask = .invalid
+            }
+        }
     }
 
     @objc private func appWillTerminate() {

--- a/PerformanceSuite/Tests/AppRenderingReceiverTests.swift
+++ b/PerformanceSuite/Tests/AppRenderingReceiverTests.swift
@@ -180,6 +180,52 @@ class AppRenderingReceiverTests: XCTestCase {
         _ = receiver
     }
 
+    func testWillResignActiveEndsSessionSynchronously() {
+        let metricsReceiver = LiveAppRenderingMetricsReceiverStub()
+        let framesMeter = FramesMeterStub()
+        let receiver = AppRenderingReporter(
+            metricsReceiver: metricsReceiver, framesMeter: framesMeter, sendingThrottleInterval: throttleInterval)
+
+        // willResignActive fires before the backend's didEnterBackground session-end, so the live
+        // session must end *synchronously* within the notification turn to win that race — no wait.
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+
+        XCTAssertEqual(
+            metricsReceiver.endedCount, 1,
+            "willResignActive must end the live session synchronously so it beats the backend session-end")
+        _ = receiver
+    }
+
+    func testDidBecomeActiveStartsSession() {
+        let metricsReceiver = LiveAppRenderingMetricsReceiverStub()
+        let framesMeter = FramesMeterStub()
+        let receiver = AppRenderingReporter(
+            metricsReceiver: metricsReceiver, framesMeter: framesMeter, sendingThrottleInterval: throttleInterval)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedCount, 1, "didBecomeActive must start a new live session")
+        _ = receiver
+    }
+
+    func testBackgroundCycleEndsThenRestarts() {
+        let metricsReceiver = LiveAppRenderingMetricsReceiverStub()
+        let framesMeter = FramesMeterStub()
+        let receiver = AppRenderingReporter(
+            metricsReceiver: metricsReceiver, framesMeter: framesMeter, sendingThrottleInterval: throttleInterval)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedCount, 2, "each foreground entry starts a fresh session")
+        XCTAssertEqual(metricsReceiver.endedCount, 1, "willResignActive ended the first session")
+        _ = receiver
+    }
+
     private func waitForThreshold() {
         let exp = expectation(description: "throttle delay")
         DispatchQueue.main.asyncAfter(deadline: .now() + throttleInterval * 2) {
@@ -196,4 +242,21 @@ class AppRenderingMetricsReceiverStub: AppRenderingMetricsReceiver {
         appRenderingMetrics = metrics
     }
     var appRenderingMetrics: RenderingMetrics?
+}
+
+/// Live variant used by the app-lifecycle (willResignActive / didBecomeActive) tests: records
+/// session start/end calls so the background-safe live-span lifecycle can be asserted.
+final class LiveAppRenderingMetricsReceiverStub: LiveAppRenderingMetricsReceiver {
+    var appRenderingMetrics: RenderingMetrics?
+    var startedCount = 0
+    var endedCount = 0
+    func appRenderingMetricsReceived(metrics: RenderingMetrics) {
+        appRenderingMetrics = metrics
+    }
+    func appRenderingSessionStarted(at startedAt: Date) {
+        startedCount += 1
+    }
+    func appRenderingSessionEnded() {
+        endedCount += 1
+    }
 }

--- a/PerformanceSuite/Tests/RenderingObserverTests.swift
+++ b/PerformanceSuite/Tests/RenderingObserverTests.swift
@@ -259,6 +259,60 @@ class RenderingObserverTests: XCTestCase {
         )
     }
 
+    func testWillResignActiveEndsLiveMeasurementThenDidBecomeActiveRestarts() {
+        // A screen-rendering span straddles an app background (no viewWillDisappear fires). End it
+        // synchronously on willResignActive — winning the race against the backend's didEnterBackground
+        // session-end — then restart a fresh measurement on didBecomeActive while the screen is visible.
+        let metricsReceiver = LiveRenderingMetricsReceiverStub()
+        let framesMeter = FramesMeterStub()
+        let observer = RenderingObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, framesMeter: framesMeter)
+
+        observer.beforeInit()
+        observer.afterViewWillAppear()
+        observer.afterViewDidAppear()
+        waitForEvents()
+        XCTAssertEqual(metricsReceiver.startedContexts.count, 1)
+        XCTAssertTrue(framesMeter.isStarted)
+
+        // Synchronous end via the live path (NOT cancel()); FramesMeter unsubscribed.
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertEqual(metricsReceiver.endedCalls.count, 1, "willResignActive ends the live measurement synchronously")
+        XCTAssertNotNil(metricsReceiver.endedCalls.first?.context, "ended via the live context, not cancel()")
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0)
+        XCTAssertFalse(framesMeter.isStarted, "FramesMeter unsubscribed on background")
+
+        // Foreground again, screen still visible → a fresh measurement restarts.
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        waitForEvents()
+        XCTAssertEqual(metricsReceiver.startedContexts.count, 2, "didBecomeActive restarts a fresh measurement")
+        XCTAssertTrue(framesMeter.isStarted, "FramesMeter re-subscribed on restart")
+
+        // A later real disappear ends the restarted measurement — exactly once more.
+        observer.beforeViewWillDisappear()
+        waitForEvents()
+        XCTAssertEqual(metricsReceiver.endedCalls.count, 2, "the restarted session ends normally on disappear")
+    }
+
+    func testWillResignActiveThenDisappearDoesNotDoubleReport() {
+        // After a resign-driven end with no restart, a later real viewWillDisappear must not
+        // re-report the already-ended span.
+        let metricsReceiver = LiveRenderingMetricsReceiverStub()
+        let framesMeter = FramesMeterStub()
+        let observer = RenderingObserver(screen: UIViewController(), metricsReceiver: metricsReceiver, framesMeter: framesMeter)
+
+        observer.beforeInit()
+        observer.afterViewWillAppear()
+        observer.afterViewDidAppear()
+        waitForEvents()
+
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertEqual(metricsReceiver.endedCalls.count, 1)
+
+        observer.beforeViewWillDisappear()
+        waitForEvents()
+        XCTAssertEqual(metricsReceiver.endedCalls.count, 1, "disappear after a resign-end must not double-report")
+    }
+
     private func waitForEvents() {
         let exp = expectation(description: "runloop")
         DispatchQueue.main.asyncAfter(deadline: .now()) {


### PR DESCRIPTION
App-rendering and screen-rendering live spans were being auto-terminated by the backend (Embrace, emb.error_code=user_abandon) on every background: the backend ends its session synchronously on didEnterBackground, while our finalize hopped through consumerQueue.async and lost the race, so span.end() no-op'd on an already-ended span (wrong duration, missing attributes, exported a session late).

Fix: end the live span synchronously on willResignActive, which fires before didEnterBackground (hence before the backend's session-end), so our clean end wins and the span ships Status.unset with the correct duration. The auto- termination attribute remains the safety net for unclean exits where willResignActive never fires (jetsam/OOM/crash while active).

- AppRenderingReporter: end synchronously on willResignActive (didEnterBackground kept as a background-task-guarded fallback); didBecomeActive already restarts the session, so transient interruptions split into separate spans (accepted).
- RenderingObserver: add app-lifecycle handling — synchronous end on willResignActive + restart on didBecomeActive while the screen is still visible, guarding processDisappear against double-reporting.