### PR TITLE
Attribute fatal-hang span to the session

### DIFF
--- a/PerformanceSuite/OTel/Sources/OTelSemanticConventions.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSemanticConventions.swift
@@ -74,6 +74,13 @@ public enum OTelSemanticConventions {
         public static let appSessionId = "app.session.id"
         public static let appSessionDurationMs = "app.session.duration.ms"
 
+        /// The backend's session-bucketing key. A session processor stamps this = the CURRENT session
+        /// on every span at start and the exporter buckets spans into the session payload by it. This is
+        /// the generic OpenTelemetry session key (Embrace's `SpanSemantics.keySessionId` is the same
+        /// `"session.id"`), so it's safe to hardcode here rather than inject — a post-facto fatal-hang
+        /// span re-stamps it (post-`startSpan`) with the session the hang happened in.
+        public static let sessionId = "session.id"
+
         // Watchdog termination
         public static let appState = "app.state"
         public static let memoryWarningsCount = "memory.warnings_count"

--- a/PerformanceSuite/OTel/Sources/OTelSpanEmitter+Signals.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSpanEmitter+Signals.swift
@@ -85,7 +85,11 @@ extension OTelSpanEmitter {
             startTime: startTime,
             endTime: endTime,
             attributes: SDKAttributeSet(values: sdkAttributes, reservedKeys: OTelSDKKeys.hang),
-            context: context
+            context: context,
+            // Fatal hangs are detected on the NEXT launch, so the span is created in session N+1.
+            // Override `session.id` (post-startSpan) with the session the hang happened in so the
+            // backend buckets it correctly instead of attributing it to the launch that reported it.
+            sessionIdOverride: info.sessionId
         )
     }
 

--- a/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
+++ b/PerformanceSuite/OTel/Sources/OTelSpanEmitter.swift
@@ -115,7 +115,8 @@ final class OTelSpanEmitter {
         startTime: Date,
         endTime: Date,
         attributes: SDKAttributeSet,
-        context: PerformanceSuiteSignalContext
+        context: PerformanceSuiteSignalContext,
+        sessionIdOverride: String? = nil
     ) {
         if let shouldEmit, !shouldEmit(context) { return }
 
@@ -127,6 +128,18 @@ final class OTelSpanEmitter {
         )
 
         let span = makeBuilder(spanName: spanName, startTime: startTime, attributes: merged).startSpan()
+        // A backend session processor (e.g. Embrace's `EmbraceSpanProcessor.onStart`) stamps the
+        // session-bucketing key = the CURRENT session on every span at start, overwriting anything set
+        // pre-start. A post-facto signal (a fatal hang detected on the NEXT launch) must be attributed
+        // to the session it actually happened in — so set the key AFTER `startSpan` so it survives the
+        // onStart overwrite and lands on the completed span exported at onEnd (the backend buckets by
+        // this attribute). The key is the generic OTel `session.id` (== Embrace's `SpanSemantics
+        // .keySessionId`), so it's hardcoded rather than injected.
+        if let sessionIdOverride {
+            span.setAttribute(
+                key: OTelSemanticConventions.Attribute.sessionId,
+                value: .string(sessionIdOverride))
+        }
         span.end(time: endTime)
     }
 

--- a/PerformanceSuite/OTel/Tests/OTelInstrumenterHangSpanTests.swift
+++ b/PerformanceSuite/OTel/Tests/OTelInstrumenterHangSpanTests.swift
@@ -157,4 +157,41 @@ final class OTelInstrumenterHangSpanTests: XCTestCase {
         XCTAssertEqual(builder.attributes["app.session.id"]?.stringValue, "sdk-session-id",
                        "OTelSDKKeys.hang reserves app.session.id, so a malicious provider cannot overwrite it")
     }
+
+    // MARK: - session.id override (backend session-bucketing key)
+
+    /// A fatal hang is detected on the NEXT launch, so its span is created in the new session and the
+    /// backend's onStart processor (e.g. Embrace's `EmbraceSpanProcessor`) would stamp `session.id` =
+    /// the new session. The emitter re-stamps `session.id` with `info.sessionId` (the session the hang
+    /// happened in) AFTER `startSpan` so it survives that overwrite. This asserts the override lands on
+    /// the *started span* and NOT on the pre-start builder — the ordering is the whole point: setting it
+    /// pre-start would let onStart clobber it back to the wrong (current) session.
+    func testFatalHangSpanOverridesSessionIdWithOriginatingSessionPostStart() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        let info = hangInfo(sessionId: "previous-session-A")
+        instrumenter.fatalHangReceived(info: info)
+
+        let builder = try XCTUnwrap(provider.tracer.lastBuilder)
+        // Pre-start: session.id must NOT be on the builder, or the backend's onStart would overwrite it.
+        XCTAssertNil(builder.attributes["session.id"],
+                     "session.id must be set AFTER startSpan, not on the pre-start builder")
+        // Post-start: the started span carries session.id = the originating (previous) session.
+        let span = try XCTUnwrap(builder.startedSpan)
+        XCTAssertEqual(span.attributes["session.id"]?.stringValue, "previous-session-A",
+                       "Fatal hang span must re-stamp session.id with info.sessionId post-startSpan")
+    }
+
+    func testFatalHangSpanOmitsSessionIdOverrideWhenInfoSessionIdIsNil() throws {
+        let provider = MockTracerProvider()
+        let instrumenter = makeInstrumenter(provider: provider)
+
+        let info = hangInfo(sessionId: nil)
+        instrumenter.fatalHangReceived(info: info)
+
+        let span = try XCTUnwrap(provider.tracer.lastBuilder?.startedSpan)
+        XCTAssertNil(span.attributes["session.id"],
+                     "With nil info.sessionId, no session.id override is set (no empty string)")
+    }
 }


### PR DESCRIPTION
A fatal hang kills the app, so its span is created on the NEXT launch (session N+1). Embrace's EmbraceSpanProcessor.onStart stamps session.id = the current session on every span at start, so the fatal-hang span was bucketed to N+1 instead of the crash session N.

Re-stamp session.id AFTER startSpan with HangInfo.sessionId (the session the hang happened in) so it survives the onStart overwrite and lands on the completed span exported at onEnd, where the backend buckets by it. The key is the generic OTel "session.id" (== Embrace's SpanSemantics.keySessionId), so it is hardcoded rather than injected.

Only emitFatalHangSpan routes through the override; non-fatal hangs are live in-session spans and are unaffected. HangInfo.sessionId was always captured and persisted correctly — the bug was writing only the proprietary app.session.id (which Embrace does not bucket by) plus the onStart overwrite.