### PR TITLE
Fix phantom crash from recovered hangs (.fatalHangsAsNonFatals) + regression tests

### DIFF
--- a/PerformanceSuite/Crashlytics/Sources/CrashlyticsIssueReporter.swift
+++ b/PerformanceSuite/Crashlytics/Sources/CrashlyticsIssueReporter.swift
@@ -76,9 +76,13 @@ class CrashlyticsIssueReporter: CrashlyticsIssueReporting {
             let model = exceptionModel(withName: type, stackTrace: stackTrace)
             Crashlytics.crashlytics().record(onDemandExceptionModel: model)
 
-            if fatalHangsAsCrashes {
-                removeFirebaseCrashMarker()
-            }
+            // `record(onDemandExceptionModel:)` records an on-demand exception, which always
+            // writes Firebase's "previously-crashed" marker (even for a non-fatal model). A
+            // recovered hang is never a crash, so we must always clear the marker here -
+            // regardless of the reporting mode - otherwise the next launch reports a phantom
+            // crash via `didCrashDuringPreviousExecution()`. This mirrors `reportHangStarted`,
+            // which also removes the marker unconditionally.
+            removeFirebaseCrashMarker()
         } catch {
             debugPrint("Failed to change hang report type with error: \(error)")
         }

--- a/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
+++ b/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
@@ -149,6 +149,15 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
         let reportPath = reporter.reportHangStarted(withType: hangType, stackTrace: stack)
         XCTAssertFalse(reportPath.isEmpty, file: file, line: line)
 
+        // The fatal report file (exception.clsrecord) is written only in the fatal-hang-as-crash
+        // mode; otherwise the event is recorded to custom_exception_a.clsrecord instead.
+        let fatalReportPath = (reportPath as NSString).appendingPathComponent("exception.clsrecord")
+        let hasFatalReport = !(((try? String(contentsOfFile: fatalReportPath)) ?? "").isEmpty)
+        XCTAssertEqual(
+            hasFatalReport, fatalHangsAsCrashes,
+            "exception.clsrecord should be present (non-empty) only when fatalHangsAsCrashes is true",
+            file: file, line: line)
+
         // 2. Hang recovers -> replace with a non-fatal report, marker should be removed again.
         reporter.changeExistingHangReport(toType: hangType, stackTrace: stack, reportPath: reportPath)
 

--- a/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
+++ b/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
@@ -157,11 +157,25 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
             "exception.clsrecord should be present (non-empty) only when fatalHangsAsCrashes is true",
             file: file, line: line)
 
-        // 2. Hang recovers -> replace with a non-fatal report, marker removed again. The
-        // on-demand recording is synchronous, so the marker is created and removed inside this
-        // call; assert as soon as it returns.
+        // The marker an on-demand recording writes must be gone after reportHangStarted. Give any
+        // deferred Crashlytics work a moment to run before checking (see below).
+        let afterReportHangStarted = expectation(description: "deferred crashlytics work")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { afterReportHangStarted.fulfill() }
+        wait(for: [afterReportHangStarted], timeout: 10)
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: markerPath),
+            "Crash marker present after reportHangStarted",
+            file: file, line: line)
+
+        // 2. Hang recovers -> replace with a non-fatal report; the marker must end up removed.
         reporter.changeExistingHangReport(toType: hangType, stackTrace: stack, reportPath: reportPath)
 
+        // `record(onDemandExceptionModel:)` runs on the main queue, and newer Firebase (>= 12.x)
+        // defers it behind a context-init promise that resolves shortly after this call - so the
+        // marker it (incorrectly) leaves appears a moment later. Wait for it to settle, then assert.
+        let afterChangeExistingHangReport = expectation(description: "deferred crashlytics work")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { afterChangeExistingHangReport.fulfill() }
+        wait(for: [afterChangeExistingHangReport], timeout: 10)
         XCTAssertFalse(
             fileManager.fileExists(atPath: markerPath),
             "Crash marker present after a recovered non-fatal hang: the next launch would mis-report it as an app crash",

--- a/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
+++ b/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
@@ -131,8 +131,7 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
     ///
     /// If the marker survives this flow, the *next* launch sees
     /// `didCrashDuringPreviousExecution() == true` and a recovered hang is mis-reported as a
-    /// crash. This must hold for both reporting modes, and even after any asynchronously-deferred
-    /// Crashlytics work has run.
+    /// crash. This must hold for both reporting modes.
     private func assertRecoveredNonFatalHangDoesNotLeaveCrashMarker(
         fatalHangsAsCrashes: Bool, file: StaticString = #file, line: UInt = #line
     ) throws {
@@ -158,15 +157,10 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
             "exception.clsrecord should be present (non-empty) only when fatalHangsAsCrashes is true",
             file: file, line: line)
 
-        // 2. Hang recovers -> replace with a non-fatal report, marker should be removed again.
+        // 2. Hang recovers -> replace with a non-fatal report, marker removed again. The
+        // on-demand recording is synchronous, so the marker is created and removed inside this
+        // call; assert as soon as it returns.
         reporter.changeExistingHangReport(toType: hangType, stackTrace: stack, reportPath: reportPath)
-
-        // Let any asynchronously-deferred Crashlytics work run. Newer Firebase defers
-        // `recordOnDemandExceptionModel` behind a context-init promise, so the on-demand
-        // recording (which re-creates the marker) may land *after* the synchronous removal.
-        let drain = expectation(description: "drain async crashlytics work")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { drain.fulfill() }
-        wait(for: [drain], timeout: 5)
 
         XCTAssertFalse(
             fileManager.fileExists(atPath: markerPath),

--- a/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
+++ b/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
@@ -111,6 +111,48 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: reportPath))
     }
 
+    /// Reproduces the full lifecycle of a *recovered* (non-fatal) hang and asserts that
+    /// Crashlytics does NOT think the app crashed afterwards.
+    ///
+    /// Real-world flow (see `CrashlyticsHangsReceiverWrapper`):
+    ///   1. The hang crosses the fatal threshold -> `reportHangStarted` records a *fatal*
+    ///      on-demand exception. Recording any on-demand exception makes Firebase write its
+    ///      `previously-crashed` marker, so we immediately remove the marker.
+    ///   2. The hang then recovers -> `changeExistingHangReport` replaces the fatal report
+    ///      with a non-fatal one and again ensures the marker is removed.
+    ///
+    /// If the marker survives this flow, the *next* launch sees
+    /// `didCrashDuringPreviousExecution() == true` and a recovered hang is mis-reported as a
+    /// crash. This must hold even after any asynchronously-deferred Crashlytics work has run.
+    func testRecoveredNonFatalHang_DoesNotLeaveCrashMarker() throws {
+        let fileManager = FileManager.default
+        let markerPath = try XCTUnwrap(getCrashMarkerFilePath())
+
+        // Start from a clean state.
+        try? fileManager.removeItem(atPath: markerPath)
+        XCTAssertFalse(fileManager.fileExists(atPath: markerPath))
+
+        let reporter = CrashlyticsIssueReporter(fatalHangsAsCrashes: true, firebaseHangReason: hangReason)
+
+        // 1. Hang starts -> fatal report recorded, marker removed.
+        let reportPath = reporter.reportHangStarted(withType: hangType, stackTrace: stack)
+        XCTAssertFalse(reportPath.isEmpty)
+
+        // 2. Hang recovers -> replace with a non-fatal report, marker removed again.
+        reporter.changeExistingHangReport(toType: hangType, stackTrace: stack, reportPath: reportPath)
+
+        // Let any asynchronously-deferred Crashlytics work run. Newer Firebase defers
+        // `recordOnDemandExceptionModel` behind a context-init promise, so the on-demand
+        // recording (which re-creates the marker) may land *after* the synchronous removal.
+        let drain = expectation(description: "drain async crashlytics work")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { drain.fulfill() }
+        wait(for: [drain], timeout: 5)
+
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: markerPath),
+            "Crash marker present after a recovered non-fatal hang: the next launch would mis-report it as an app crash")
+    }
+
     // Helper method to get the crash marker file path
     private func getCrashMarkerFilePath() -> String? {
         guard let crashedMarkerFileName = String(utf8String: FIRCLSCrashedMarkerFileName),

--- a/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
+++ b/PerformanceSuite/Tests/CrashlyticsIssueReporterTests.swift
@@ -111,34 +111,45 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: reportPath))
     }
 
+    func testRecoveredNonFatalHang_DoesNotLeaveCrashMarker_WhenFatalHangsAsCrashesIsTrue() throws {
+        try assertRecoveredNonFatalHangDoesNotLeaveCrashMarker(fatalHangsAsCrashes: true)
+    }
+
+    func testRecoveredNonFatalHang_DoesNotLeaveCrashMarker_WhenFatalHangsAsCrashesIsFalse() throws {
+        try assertRecoveredNonFatalHangDoesNotLeaveCrashMarker(fatalHangsAsCrashes: false)
+    }
+
     /// Reproduces the full lifecycle of a *recovered* (non-fatal) hang and asserts that
     /// Crashlytics does NOT think the app crashed afterwards.
     ///
     /// Real-world flow (see `CrashlyticsHangsReceiverWrapper`):
-    ///   1. The hang crosses the fatal threshold -> `reportHangStarted` records a *fatal*
-    ///      on-demand exception. Recording any on-demand exception makes Firebase write its
+    ///   1. The hang crosses the fatal threshold -> `reportHangStarted` records an on-demand
+    ///      exception. Recording any on-demand exception makes Firebase write its
     ///      `previously-crashed` marker, so we immediately remove the marker.
-    ///   2. The hang then recovers -> `changeExistingHangReport` replaces the fatal report
-    ///      with a non-fatal one and again ensures the marker is removed.
+    ///   2. The hang then recovers -> `changeExistingHangReport` replaces that report with a
+    ///      non-fatal one and again ensures the marker is removed.
     ///
     /// If the marker survives this flow, the *next* launch sees
     /// `didCrashDuringPreviousExecution() == true` and a recovered hang is mis-reported as a
-    /// crash. This must hold even after any asynchronously-deferred Crashlytics work has run.
-    func testRecoveredNonFatalHang_DoesNotLeaveCrashMarker() throws {
+    /// crash. This must hold for both reporting modes, and even after any asynchronously-deferred
+    /// Crashlytics work has run.
+    private func assertRecoveredNonFatalHangDoesNotLeaveCrashMarker(
+        fatalHangsAsCrashes: Bool, file: StaticString = #file, line: UInt = #line
+    ) throws {
         let fileManager = FileManager.default
         let markerPath = try XCTUnwrap(getCrashMarkerFilePath())
 
         // Start from a clean state.
         try? fileManager.removeItem(atPath: markerPath)
-        XCTAssertFalse(fileManager.fileExists(atPath: markerPath))
+        XCTAssertFalse(fileManager.fileExists(atPath: markerPath), file: file, line: line)
 
-        let reporter = CrashlyticsIssueReporter(fatalHangsAsCrashes: true, firebaseHangReason: hangReason)
+        let reporter = CrashlyticsIssueReporter(fatalHangsAsCrashes: fatalHangsAsCrashes, firebaseHangReason: hangReason)
 
-        // 1. Hang starts -> fatal report recorded, marker removed.
+        // 1. Hang starts -> report recorded, marker removed.
         let reportPath = reporter.reportHangStarted(withType: hangType, stackTrace: stack)
-        XCTAssertFalse(reportPath.isEmpty)
+        XCTAssertFalse(reportPath.isEmpty, file: file, line: line)
 
-        // 2. Hang recovers -> replace with a non-fatal report, marker removed again.
+        // 2. Hang recovers -> replace with a non-fatal report, marker should be removed again.
         reporter.changeExistingHangReport(toType: hangType, stackTrace: stack, reportPath: reportPath)
 
         // Let any asynchronously-deferred Crashlytics work run. Newer Firebase defers
@@ -150,7 +161,8 @@ final class CrashlyticsIssueReporterTests: XCTestCase {
 
         XCTAssertFalse(
             fileManager.fileExists(atPath: markerPath),
-            "Crash marker present after a recovered non-fatal hang: the next launch would mis-report it as an app crash")
+            "Crash marker present after a recovered non-fatal hang: the next launch would mis-report it as an app crash",
+            file: file, line: line)
     }
 
     // Helper method to get the crash marker file path


### PR DESCRIPTION
## What

1. Adds regression tests covering the crash-marker invariant for a **recovered (non-fatal) hang**, across both reporting modes (`CrashlyticsIssueReporterTests`).
2. **Fixes** a crash-marker leak in `changeExistingHangReport` for `.fatalHangsAsNonFatals`.

## The bug

When a hang crosses the fatal threshold and then recovers, `changeExistingHangReport` records a non-fatal on-demand exception and is supposed to ensure Firebase's `previously-crashed` marker is gone — so the next launch doesn't mis-report the recovered hang as a crash via `didCrashDuringPreviousExecution()`.

The subtlety: `record(onDemandExceptionModel:)` goes through `FIRCLSExceptionRecordOnDemand`, which calls `FIRCLSHandler` **unconditionally** — so it writes the `previously-crashed` marker even for a *non-fatal* model. (The normal `recordExceptionModel:` path differs: only native exceptions hit the handler, so an ordinary non-fatal does **not** write the marker.)

`changeExistingHangReport` only removed the marker when `fatalHangsAsCrashes == true`:

```swift
Crashlytics.crashlytics().record(onDemandExceptionModel: model)   // writes the marker
if fatalHangsAsCrashes {                                          // ← gated
    removeFirebaseCrashMarker()
}
```

So in `.fatalHangsAsNonFatals` mode the marker was left behind, and every recovered (detected) hang produced a phantom `app_crash` on the next launch.

Note this is orthogonal to the Firebase crash/non-fatal classification: that comes from the report files (`exception.clsrecord` + fatal indicator vs `custom_exception_a.clsrecord`), not from the marker. The marker only drives `didCrashDuringPreviousExecution()`. A recovered hang should never set it — which is why `reportHangStarted` already removes it unconditionally in both modes.

## The fix

Remove the marker unconditionally in `changeExistingHangReport`, matching `reportHangStarted`:

```swift
Crashlytics.crashlytics().record(onDemandExceptionModel: model)
removeFirebaseCrashMarker()
```

## Tests

- `testRecoveredNonFatalHang_DoesNotLeaveCrashMarker_WhenFatalHangsAsCrashesIsTrue`
- `testRecoveredNonFatalHang_DoesNotLeaveCrashMarker_WhenFatalHangsAsCrashesIsFalse` (the one this fix makes pass)
- Both drive the full `reportHangStarted` → `changeExistingHangReport` flow against real Firebase and assert the crash marker is absent afterwards. The shared helper also asserts the fatal report file (`exception.clsrecord`) is present only in `fatalHangsAsCrashes` mode.

All `CrashlyticsIssueReporterTests` pass on the pinned **FirebaseCrashlytics 12.8.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)