### PR TITLE
Fix flaky MainThreadCallStackTests.testCallStack (raise timeout)

### DIFF
--- a/PerformanceSuite/Tests/MainThreadCallStackTests.swift
+++ b/PerformanceSuite/Tests/MainThreadCallStackTests.swift
@@ -21,7 +21,11 @@ import XCTest
                 XCTAssert(stack.contains("XCTestCore"))
                 exp.fulfill()
             }
-            waitForExpectations(timeout: 1)
+            // `readStack()` suspends the main thread while it walks the stack. Under CI CPU
+            // contention the background thread can be descheduled inside that window, freezing the
+            // main thread (which is waiting here) long enough to blow a tight deadline. This isn't a
+            // timing test, so use a generous timeout - it still completes in milliseconds normally.
+            waitForExpectations(timeout: 10)
         }
 
         func testCallStackConversion() throws {

--- a/PerformanceSuite/Tests/MainThreadCallStackTests.swift
+++ b/PerformanceSuite/Tests/MainThreadCallStackTests.swift
@@ -21,10 +21,6 @@ import XCTest
                 XCTAssert(stack.contains("XCTestCore"))
                 exp.fulfill()
             }
-            // `readStack()` suspends the main thread while it walks the stack. Under CI CPU
-            // contention the background thread can be descheduled inside that window, freezing the
-            // main thread (which is waiting here) long enough to blow a tight deadline. This isn't a
-            // timing test, so use a generous timeout - it still completes in milliseconds normally.
             waitForExpectations(timeout: 10)
         }
 


### PR DESCRIPTION
## Problem

`MainThreadCallStackTests.testCallStack` intermittently fails on CI with:

```
Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "test".
testCallStack failed (7.412 seconds)
```

The `7.4s` for a `1s` timeout is the tell.

## Cause

`MainThreadCallStack.readStack()` (called from a background queue) does `thread_suspend(main)` → walk the stack → `thread_resume(main)`. The test's main thread is parked in `waitForExpectations(timeout: 1)`. Under CI CPU contention the background thread can be descheduled **inside** the suspend/resume window, so the main thread stays frozen — unable to fulfill the expectation or service the 1s deadline. When it finally resumes, XCTest immediately reports the (long-since) blown deadline.

It's a scheduling delay, not a deadlock, and not a real assertion failure (`fulfill()` runs regardless of the `XCTAssert`).

## Fix

This isn't a timing test — it verifies `readStack()` returns the main thread's stack (containing `XCTestCore`). Raise the timeout `1` → `10` so CI scheduling jitter can't fail it. It still completes in ~milliseconds normally (verified locally: 0.015s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)