### PR TITLE
Bump FirebaseCrashlytics to 12.15.0 (newest < 13)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "bb4002485ff867768dec13bf904a2ddb050bd1b1",
+        "version" : "11.3.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "674d9a7ee9858207181a3dd0b42c77298c6fb71b",
-        "version" : "12.8.0"
+        "revision" : "42e81d245e30e49ea6a5830cf2842d44a1591270",
+        "version" : "12.15.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
-        "version" : "3.2.0"
+        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
+        "version" : "3.6.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "2ffd220823f3716904733162e9ae685545c276d1",
-        "version" : "12.8.0"
+        "revision" : "144855f40d8668927f256a3045f7fdc4c3f4338b",
+        "version" : "12.15.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "10.0.0"..<"13.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "12.11.0"..<"13.0.0"),
         .package(url: "https://github.com/yene/GCDWebServer", exact: .init(3, 5, 7)),
         .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.0.0"),
     ],

--- a/PerformanceSuite.podspec
+++ b/PerformanceSuite.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     cr_spec.source_files = 'PerformanceSuite/Crashlytics/Sources/*.swift', 'PerformanceSuite/Crashlytics/Imports/include/*.h'  
     cr_spec.public_header_files = 'PerformanceSuite/Crashlytics/Imports/include/*.h'
     cr_spec.dependency 'PerformanceSuite/Core'
-    cr_spec.dependency 'FirebaseCrashlytics'
+    cr_spec.dependency 'FirebaseCrashlytics', '>= 12.11.0', '< 13.0.0'
   end
 
   s.subspec 'OTel' do |otel_spec|

--- a/PerformanceSuite/Crashlytics/Imports/include/CrashlyticsAdapter.h
+++ b/PerformanceSuite/Crashlytics/Imports/include/CrashlyticsAdapter.h
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// with the different hang type.
 NSString *FIRCLSExceptionRecordOnDemandModel(FIRExceptionModel *exceptionModel,
                                              int previousRecordedOnDemandExceptions,
-                                             int previousDroppedOnDemandExceptions);
+                                             int previousDroppedOnDemandExceptions,
+                                             BOOL shouldSuspendThread);
 
 /// We need to pass proper type (first argument) to this method
 /// to record stack traces of all the methods, 
@@ -25,7 +26,8 @@ NSString *FIRCLSExceptionRecordOnDemand(int type,
                                         NSArray<FIRStackFrame *> *frames,
                                         BOOL fatal,
                                         int previousRecordedOnDemandExceptions,
-                                        int previousDroppedOnDemandExceptions);
+                                        int previousDroppedOnDemandExceptions,
+                                        BOOL shouldSuspendThread);
 
 
 /// Firebase marker file which indicates that exception happened during the previous launch.
@@ -47,6 +49,14 @@ extern const char *FIRCLSCrashedMarkerFileName;
 /// because `recordExceptionModel` will send data only on the next launch,
 /// but we want to send non-fatal hang events as soon as we receive it.
 - (void)recordOnDemandExceptionModel:(FIRExceptionModel *)exceptionModel;
+
+/// Since Firebase 12.11.0 the record/log APIs (including `recordOnDemandExceptionModel:`)
+/// no longer run synchronously - their work is deferred onto an internal context-init
+/// promise. We expose this private helper so we can chain our crash-marker removal onto
+/// the same promise *after* an on-demand record, guaranteeing the removal runs after the
+/// deferred record has (re)written Firebase's "previously-crashed" marker. Without this,
+/// a synchronous removal would race ahead of the deferred write and the marker would survive.
+- (void)waitForContextInit:(NSString *)contextLog callback:(void (^)(void))callback;
 
 /// We need file manager to get `rootPath` folder
 @property(nonatomic, readonly, nullable) id<RootPathProvider> fileManager;

--- a/PerformanceSuite/Crashlytics/Sources/CrashlyticsIssueReporter.swift
+++ b/PerformanceSuite/Crashlytics/Sources/CrashlyticsIssueReporter.swift
@@ -47,13 +47,17 @@ class CrashlyticsIssueReporter: CrashlyticsIssueReporting {
             }
 
             // We are passing crash error type here, so that stack trace is recorded
-            // for all the threads
-            result = FIRCLSExceptionRecordOnDemand(firebaseNativeErrorType, name, reason, model.stackTrace, true, 0, 0)
+            // for all the threads.
+            // Last argument is `shouldSuspendThread` (added in Firebase 11.9.0); we pass `true`
+            // to match Firebase's own default and preserve the all-thread snapshot behavior.
+            result = FIRCLSExceptionRecordOnDemand(firebaseNativeErrorType, name, reason, model.stackTrace, true, 0, 0, true)
         } else {
             // We are not using `record(onDemandExceptionModel: model)` here,
             // because then the report will be sent right away,
             // but we do not know if it should by fatal or non-fatal hang yet.
-            result = FIRCLSExceptionRecordOnDemandModel(model, 0, 0)
+            // Last argument is `shouldSuspendThread` (added in Firebase 11.9.0); we pass `true`
+            // to match Firebase's own default.
+            result = FIRCLSExceptionRecordOnDemandModel(model, 0, 0, true)
         }
 
         // Ensure, that crash marker is not created
@@ -74,7 +78,8 @@ class CrashlyticsIssueReporter: CrashlyticsIssueReporting {
             try FileManager.default.removeItem(atPath: reportPath)
 
             let model = exceptionModel(withName: type, stackTrace: stackTrace)
-            Crashlytics.crashlytics().record(onDemandExceptionModel: model)
+            let crashlytics = Crashlytics.crashlytics()
+            crashlytics.record(onDemandExceptionModel: model)
 
             // `record(onDemandExceptionModel:)` records an on-demand exception, which always
             // writes Firebase's "previously-crashed" marker (even for a non-fatal model). A
@@ -82,7 +87,24 @@ class CrashlyticsIssueReporter: CrashlyticsIssueReporting {
             // regardless of the reporting mode - otherwise the next launch reports a phantom
             // crash via `didCrashDuringPreviousExecution()`. This mirrors `reportHangStarted`,
             // which also removes the marker unconditionally.
-            removeFirebaseCrashMarker()
+            //
+            // Since Firebase 12.11.0, `record(onDemandExceptionModel:)` defers its work (the
+            // marker write included) onto an internal context-init promise instead of running
+            // synchronously. A synchronous `removeFirebaseCrashMarker()` here would race ahead
+            // of that deferred write, leaving the marker in place. We chain our removal on the
+            // same promise via `waitForContextInit` *after* the record call: FBLPromise invokes
+            // observers in registration order on the main queue, and the record's marker write
+            // is synchronous within its own observer, so our removal is guaranteed to run after
+            // the marker has been (re)written. (`reportHangStarted` is unaffected: it records
+            // through the synchronous `FIRCLSExceptionRecordOnDemand*` C functions, which Firebase
+            // never wrapped.)
+            // Capture `self` strongly: the removal must run even if the caller releases this
+            // reporter before the promise resolves (otherwise the deferred marker *write* would
+            // survive with no removal). The closure is owned by Firebase's one-shot promise
+            // observer, not by `self`, so there is no retain cycle.
+            crashlytics.wait(forContextInit: "perfSuiteHangMarkerRemoval") {
+                self.removeFirebaseCrashMarker()
+            }
         } catch {
             debugPrint("Failed to change hang report type with error: \(error)")
         }

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,6 @@ target :Project
 platform :ios, deployment_target
 use_frameworks!
 pod 'PerformanceSuite', :path  => '.', :appspecs => ['PerformanceApp'], :testspecs => ['Tests', 'UITests']
-pod 'FirebaseCrashlytics', '~> 12.0'
 pod 'SwiftLint'
 
 post_install do |installer|

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ target :Project
 platform :ios, deployment_target
 use_frameworks!
 pod 'PerformanceSuite', :path  => '.', :appspecs => ['PerformanceApp'], :testspecs => ['Tests', 'UITests']
+pod 'FirebaseCrashlytics', '~> 12.0'
 pod 'SwiftLint'
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,31 +1,31 @@
 PODS:
-  - FirebaseCore (12.8.0):
-    - FirebaseCoreInternal (~> 12.8.0)
+  - FirebaseCore (12.15.0):
+    - FirebaseCoreInternal (~> 12.15.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreExtension (12.8.0):
-    - FirebaseCore (~> 12.8.0)
-  - FirebaseCoreInternal (12.8.0):
+  - FirebaseCoreExtension (12.15.0):
+    - FirebaseCore (~> 12.15.0)
+  - FirebaseCoreInternal (12.15.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseCrashlytics (12.8.0):
-    - FirebaseCore (~> 12.8.0)
-    - FirebaseInstallations (~> 12.8.0)
-    - FirebaseRemoteConfigInterop (~> 12.8.0)
-    - FirebaseSessions (~> 12.8.0)
+  - FirebaseCrashlytics (12.15.0):
+    - FirebaseCore (~> 12.15.0)
+    - FirebaseInstallations (~> 12.15.0)
+    - FirebaseRemoteConfigInterop (~> 12.15.0)
+    - FirebaseSessions (~> 12.15.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseInstallations (12.8.0):
-    - FirebaseCore (~> 12.8.0)
+  - FirebaseInstallations (12.15.0):
+    - FirebaseCore (~> 12.15.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - FirebaseRemoteConfigInterop (12.8.0)
-  - FirebaseSessions (12.8.0):
-    - FirebaseCore (~> 12.8.0)
-    - FirebaseCoreExtension (~> 12.8.0)
-    - FirebaseInstallations (~> 12.8.0)
+  - FirebaseRemoteConfigInterop (12.15.0)
+  - FirebaseSessions (12.15.0):
+    - FirebaseCore (~> 12.15.0)
+    - FirebaseCoreExtension (~> 12.15.0)
+    - FirebaseInstallations (~> 12.15.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
@@ -37,15 +37,15 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - GoogleUtilities/Environment (8.1.0):
+  - GoogleUtilities/Environment (8.1.1):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.0):
+  - GoogleUtilities/Logger (8.1.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - "GoogleUtilities/NSData+zlib (8.1.0)":
+  - "GoogleUtilities/NSData+zlib (8.1.1)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.0)
-  - GoogleUtilities/UserDefaults (8.1.0):
+  - GoogleUtilities/Privacy (8.1.1)
+  - GoogleUtilities/UserDefaults (8.1.1):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - nanopb (3.30910.0):
@@ -72,12 +72,13 @@ PODS:
   - PerformanceSuite/UITests (1.10.1):
     - GCDWebServer
     - PerformanceSuite/PerformanceApp
-  - PromisesObjC (2.4.0)
-  - PromisesSwift (2.4.0):
-    - PromisesObjC (= 2.4.0)
+  - PromisesObjC (2.4.1)
+  - PromisesSwift (2.4.1):
+    - PromisesObjC (= 2.4.1)
   - SwiftLint (0.63.2)
 
 DEPENDENCIES:
+  - FirebaseCrashlytics (~> 12.0)
   - PerformanceSuite (from `.`)
   - PerformanceSuite/PerformanceApp (from `.`)
   - PerformanceSuite/Tests (from `.`)
@@ -107,23 +108,23 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
-  FirebaseCoreExtension: 6605938d51f765d8b18bfcafd2085276a252bee2
-  FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
-  FirebaseCrashlytics: fb31c6907e5b52aa252668394d3f1ab326df1511
-  FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
-  FirebaseRemoteConfigInterop: 869ddca16614f979e5c931ece11fbb0b8729ed41
-  FirebaseSessions: d614ca154c63dbbc6c10d6c38259c2162c4e7c9b
+  FirebaseCore: 2e86a4ea1684d4381707069e4a6d89ac808e901e
+  FirebaseCoreExtension: 10d2a627977b39418759ad88ada80fbbd34f1c4f
+  FirebaseCoreInternal: 6ab6a02c94446c026d2cf35cf5383842ebaa4992
+  FirebaseCrashlytics: 87e76cc33259b076dd1f96cd829db76849338e08
+  FirebaseInstallations: eb29ccbf64eaedf86fd5b2ccc7fabde567660b52
+  FirebaseRemoteConfigInterop: 7e3d57ce4b1e958bb1d15403faa7178f46bbb5b7
+  FirebaseSessions: acfe7eadca47cda94ac86592737204581bb1abf6
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OpenTelemetry-Swift-Api: 3d77582ab6837a63b65bf7d2eacc57d8f2595edd
   PerformanceSuite: 6921686c72fc17ee5034b0cf327a45c82460e1d6
-  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
+  PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
+  PromisesSwift: 217dea0fd5d2ad65222a109c48698add13cc1c5b
   SwiftLint: 4fa4a9b437ccc4fc72f6c0bc98556e8e9e05bccf
 
-PODFILE CHECKSUM: f3965e51873eedff05cd888f3eed63c63e8f2c11
+PODFILE CHECKSUM: 9eb2792b2e8a8b5ad47784c0f931c16170885776
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Bumps FirebaseCrashlytics to **12.15.0** (newest 12.x) and fixes a hang/crash-marker regression that the bump surfaces, plus a latent ABI mismatch.

### The regression (Firebase 12.11.0)
Since **12.11.0** ([firebase-ios-sdk#15879](https://github.com/firebase/firebase-ios-sdk/pull/15879)), the Crashlytics record/log APIs no longer run synchronously — their work is deferred onto an internal context-init promise. `changeExistingHangReport` recorded a recovered non-fatal hang via `record(onDemandExceptionModel:)` and then **synchronously** removed Firebase's `previously-crashed` marker. With the deferral, the record (and its marker write) now runs *after* our removal — so the marker survives and the next launch mis-reports the recovered hang as a phantom app crash.

Verified at the version boundary: `recordOnDemandExceptionModel:` is synchronous in 12.10.0 and wrapped in `waitForContextInit:` in 12.11.0.

### The fix
- Expose the private `waitForContextInit:callback:` on our `FIRCrashlytics (OnDemandException)` category and chain the marker removal on the **same** promise, *after* the record call. FBLPromise invokes observers in registration order on the main queue, and the record's marker write is synchronous within its own observer, so our removal is guaranteed to run after the marker is (re)written.
- The removal closure captures `self` **strongly** — it must run even if the caller releases the reporter before the promise resolves (otherwise the deferred *write* would survive with no removal). The closure is owned by the one-shot promise observer, so there is no retain cycle.
- `reportHangStarted` is unchanged: it records through the synchronous `FIRCLSExceptionRecordOnDemand*` C functions, which Firebase never wrapped.

We keep `record(onDemandExceptionModel:)` (immediate upload of the recovered non-fatal hang) rather than switching to the synchronous C function, preserving existing send-right-away behavior.

### Latent ABI fix (Firebase 11.9.0)
`FIRCLSExceptionRecordOnDemandModel` and `FIRCLSExceptionRecordOnDemand` each gained a trailing `BOOL shouldSuspendThread` argument in **11.9.0**. PerfSuite's declarations/calls were still 3-/7-arg, so the new parameter read garbage. Declarations and call sites now pass `true` (Firebase's own default).

### Version floor
`Package.swift` and the podspec now require **`>= 12.11.0, < 13.0.0`** — 12.11.0 is the release where `recordOnDemandExceptionModel:` became deferred (and `waitForContextInit:` wraps it), which is the behavior this fix depends on. `Package.resolved` resolves to 12.15.0.

### Verification
- `PerformanceSuiteCrashlytics` SPM scheme builds against the real 12.15.0 SDK.
- `CrashlyticsIssueReporterTests` and `CrashlyticsHangsReceiverWrapperTests` pass (full classes, not just isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)