### PR TITLE
README follow-up: fix code-reference errors, shorten wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func appRenderingMetricsReceived(metrics: RenderingMetrics) { ... }
 
 ```
 
-For screen-level metrics you should return `ScreenIdentifier` from `screenIdentifier(for:)` or nil if this view controller shouldn't be tracked. Check [Screen identifiers] for the example.
+For screen-level metrics you should return `ScreenIdentifier` from `screenIdentifier(for:)` or nil if this view controller shouldn't be tracked. Check [Screen identifiers](#screen-identifiers) for the example.
 
 ```swift
 
@@ -112,7 +112,7 @@ pod 'PerformanceSuite'
 Currently CocoaPods repo [has problems](https://github.com/CocoaPods/cocoapods.org/issues/424) with indexing the new added pods, that's why if it doesn't work you may specify the source url and tag
 
 ```
-pod 'PerformanceSuite', :git => 'https://github.com/bookingcom/perfsuite-ios.git', :tag => '0.0.4' # use the last released version here
+pod 'PerformanceSuite', :git => 'https://github.com/bookingcom/perfsuite-ios.git', :tag => '1.10.1' # use the last released version here
 ```
 
 ## Usage
@@ -121,7 +121,7 @@ To receive performance events, you must have a class implementing some of the fo
 - `TTIMetricsReceiver`
 - `RenderingMetricsReceiver` 
 - `AppRenderingMetricsReceiver`
-- `WatchDogTerminationsReceiver`
+- `WatchdogTerminationsReceiver`
 - `HangsReceiver`
 - `ViewControllerLeaksReceiver` 
 - `StartupTimeReceiver`
@@ -218,7 +218,7 @@ class MetricsConsumer: TTIMetricsReceiver {
 
     func ttiMetricsReceived(metrics: TTIMetrics, screen: PerformanceScreen) {
         // send the event to your backend with this identifier
-        send(metric: "tti", value: metrics.tti.seconds, screen: performanceScreen.rawValue)
+        send(metric: "tti", value: metrics.tti.milliseconds, screen: screen.rawValue)
     }
 }
 
@@ -230,7 +230,7 @@ class MetricsConsumer: TTIMetricsReceiver {
 
 Instead of `PerformanceMonitoring.enable(...)`, you call `enableWithCrashlyticsSupport(...)`, which reads `didCrashPreviously` from Crashlytics for you and wraps your `HangsReceiver` so every hang is also reported to Crashlytics.
 
-#### See the [Crashlytics Integration wiki page](https://github.com/bookingcom/perfsuite-ios/wiki/Crashlytics-Integration) for installation, usage, reporting modes (`CrashlyticsHangsSettings`), and the fatal/non-fatal reporting lifecycle.
+#### See the [Crashlytics Integration wiki page](https://github.com/bookingcom/perfsuite-ios/wiki/Crashlytics-Integration).
 
 ## OpenTelemetry Integration
 
@@ -238,7 +238,7 @@ Instead of `PerformanceMonitoring.enable(...)`, you call `enableWithCrashlyticsS
 
 `OTelInstrumenter<Screen, Fragment>` conforms to all eight `PerformanceSuite` receiver protocols, so you can pass it wherever the library expects a receiver — on its own or combined with your existing receivers via the core `Multi*Receiver` types.
 
-#### See the [OpenTelemetry Integration wiki page](https://github.com/bookingcom/perfsuite-ios/wiki/OpenTelemetry-Integration) for installation, standalone and combined usage, host attribute enrichment, emission filtering, live spans, previous-session correlation, and semantic conventions.
+#### See the [OpenTelemetry Integration wiki page](https://github.com/bookingcom/perfsuite-ios/wiki/OpenTelemetry-Integration).
 
 ## How to reproduce metrics?
 


### PR DESCRIPTION

## Fixes
- **`WatchDogTerminationsReceiver` → `WatchdogTerminationsReceiver`** — correct protocol casing (the old spelling doesn't exist / wouldn't compile).
- **`[Screen identifiers]` → `[Screen identifiers](#screen-identifiers)`** — the link had no target and rendered as literal bracketed text.
- **TTI sample** — use the in-scope `screen` parameter and `.milliseconds` instead of the undefined `performanceScreen` and the sub-second-truncating `.seconds`.
- **CocoaPods tag example** `0.0.4` → `1.10.1` (current release).

## Cleanup
- Drop the long trailing descriptions after the Crashlytics and OpenTelemetry wiki links, leaving just the link.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)