### PR TITLE
Add UI test coverage for the Firebase Crashlytics integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
 
       # we need pods to download SwiftLint
       - name: Install CocoaPods
-        if: steps.cache-pods.outputs.cache-hit != 'true'
+        # Always run, even on a Pods cache hit, so the generated project picks up newly
+        # added/removed source files (e.g. new test files); otherwise they are never compiled
+        # or run. The cache still skips re-downloading unchanged pods.
         run: |
           pod install
 
@@ -95,7 +97,9 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Install CocoaPods
-        if: steps.cache-pods.outputs.cache-hit != 'true'
+        # Always run, even on a Pods cache hit, so the generated project picks up newly
+        # added/removed source files (e.g. new test files); otherwise they are never compiled
+        # or run. The cache still skips re-downloading unchanged pods.
         run: |
           pod install
 
@@ -180,7 +184,9 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Install CocoaPods
-        if: steps.cache-pods.outputs.cache-hit != 'true'
+        # Always run, even on a Pods cache hit, so the generated project picks up newly
+        # added/removed source files (e.g. new test files); otherwise they are never compiled
+        # or run. The cache still skips re-downloading unchanged pods.
         run: |
           pod install
 

--- a/PerformanceSuite/PerformanceApp/AppDelegate.swift
+++ b/PerformanceSuite/PerformanceApp/AppDelegate.swift
@@ -5,9 +5,17 @@
 //  Created by Gleb Tarasov on 30/11/2021.
 //
 
+import FirebaseCore
+import FirebaseCrashlytics
 import PerformanceSuite
 import SwiftUI
 import UIKit
+
+// In SwiftPM the Crashlytics support is a separate module; in CocoaPods it is part of
+// `PerformanceSuite`. Mirror the import style used by the Crashlytics sources.
+#if canImport(PerformanceSuiteCrashlytics)
+import PerformanceSuiteCrashlytics
+#endif
 
 @main
 class AppDelegate: NSObject, UIApplicationDelegate {
@@ -15,20 +23,13 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
 
-        let didCrash = CrashesInterceptor.didCrashDuringPreviousLaunch()
-        CrashesInterceptor.interceptCrashes()
-
         UITestsHelper.prepareForTestsIfNeeded()
 
         let metricsConsumer = MetricsConsumer()
-        do {
-            try PerformanceMonitoring.enable(config: .all(receiver: metricsConsumer), didCrashPreviously: didCrash)
-        } catch {
-            preconditionFailure("Couldn't initialize PerformanceSuite: \(error)")
-        }
-
-        if didCrash {
-            metricsConsumer.interop?.send(message: .crash)
+        if crashlyticsEnabled {
+            startWithCrashlyticsSupport(metricsConsumer: metricsConsumer)
+        } else {
+            startWithCustomCrashInterceptor(metricsConsumer: metricsConsumer)
         }
 
         let tc = UITabBarController()
@@ -40,6 +41,66 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         window.backgroundColor = .red
         self.window = window
         return true
+    }
+
+    // MARK: - Startup variants
+
+    private var crashlyticsEnabled: Bool {
+        ProcessInfo.processInfo.environment[crashlyticsKey] != nil
+    }
+
+    /// Default startup: a lightweight custom crash interceptor (no Firebase).
+    private func startWithCustomCrashInterceptor(metricsConsumer: MetricsConsumer) {
+        let didCrash = CrashesInterceptor.didCrashDuringPreviousLaunch()
+        CrashesInterceptor.interceptCrashes()
+
+        do {
+            try PerformanceMonitoring.enable(config: .all(receiver: metricsConsumer), didCrashPreviously: didCrash)
+        } catch {
+            preconditionFailure("Couldn't initialize PerformanceSuite: \(error)")
+        }
+
+        if didCrash {
+            metricsConsumer.interop?.send(message: .crash)
+        }
+    }
+
+    /// UI-test startup that boots through real Firebase Crashlytics, so tests can exercise the
+    /// Crashlytics `previously-crashed` marker path (recovered-hang phantom crashes). The marker is
+    /// the single source of truth here: if it is set on this launch, Crashlytics believes the
+    /// previous run crashed, so we surface that as `.crash`.
+    private func startWithCrashlyticsSupport(metricsConsumer: MetricsConsumer) {
+        Self.configureFirebaseIfNeeded()
+        let crashlytics = Crashlytics.crashlytics()
+        let didCrash = crashlytics.didCrashDuringPreviousExecution()
+
+        let reportingMode: CrashlyticsHangsReportingMode =
+            ProcessInfo.processInfo.environment[crashlyticsHangsAsNonFatalsKey] != nil
+            ? .fatalHangsAsNonFatals
+            : .fatalHangsAsCrashes
+
+        do {
+            try PerformanceMonitoring.enableWithCrashlyticsSupport(
+                config: .all(receiver: metricsConsumer),
+                settings: CrashlyticsHangsSettings(reportingMode: reportingMode),
+                crashlyticsEnabledInDebug: true)
+        } catch {
+            preconditionFailure("Couldn't initialize PerformanceSuite: \(error)")
+        }
+
+        if didCrash {
+            metricsConsumer.interop?.send(message: .crash)
+        }
+    }
+
+    private static func configureFirebaseIfNeeded() {
+        guard FirebaseApp.app() == nil else { return }
+        // Dummy options - we never talk to a real Firebase backend in UI tests; we only need
+        // Crashlytics' on-device report/marker machinery.
+        let options = FirebaseOptions(googleAppID: "1:11111111111:ios:aa1a1111111111a1", gcmSenderID: "123")
+        options.projectID = "abc-xyz-123"
+        options.apiKey = "A12345678901234567890123456789012345678"
+        FirebaseApp.configure(options: options)
     }
 
     func makeMenuController() -> UIViewController {

--- a/PerformanceSuite/PerformanceApp/IssuesSimulator.swift
+++ b/PerformanceSuite/PerformanceApp/IssuesSimulator.swift
@@ -8,17 +8,28 @@
 import Foundation
 
 class IssuesSimulator {
+
+    /// Optional delay (seconds) before a simulated issue actually happens. UI tests use it to send
+    /// the app to the background first, so the crash/hang occurs while backgrounded.
+    private static var actionDelay: TimeInterval {
+        guard let raw = ProcessInfo.processInfo.environment[actionDelayKey],
+              let value = TimeInterval(raw) else {
+            return 0
+        }
+        return value
+    }
+
     static func simulateNonFatalHang() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + actionDelay + 0.5) {
             Thread.sleep(forTimeInterval: 6)
         }
     }
 
     static func simulateFatalHang() {
         let lock = NSLock()
-        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + actionDelay + 0.5) {
             lock.lock()
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(700)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
                 lock.lock()
             }
         }
@@ -29,9 +40,11 @@ class IssuesSimulator {
     }
 
     static func simulateCrash() {
-        let a = 4
-        let b = Int.random(in: 0...1) * (a - 4)
-        let c = a / b
-        print("Will not be executed \(c)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + actionDelay) {
+            let a = 4
+            let b = Int.random(in: 0...1) * (a - 4)
+            let c = a / b
+            print("Will not be executed \(c)")
+        }
     }
 }

--- a/PerformanceSuite/PerformanceApp/UITestsInterop.swift
+++ b/PerformanceSuite/PerformanceApp/UITestsInterop.swift
@@ -13,6 +13,18 @@ import GCDWebServer
 public let inTestsKey = "UI_TESTS"
 public let clearStorageKey = "CLEAR_STORAGE"
 public let startupFatalHangKey = "STARTUP_FATAL_HANG"
+/// When set, the app boots through `enableWithCrashlyticsSupport` (real Firebase Crashlytics)
+/// instead of the lightweight custom crash interceptor, so UI tests can exercise the Crashlytics
+/// `previously-crashed` marker path - e.g. the recovered-hang phantom-crash regression.
+public let crashlyticsKey = "CRASHLYTICS"
+/// When set (alongside `crashlyticsKey`), fatal hangs are reported as non-fatals
+/// (`CrashlyticsHangsReportingMode.fatalHangsAsNonFatals`) instead of the default
+/// `.fatalHangsAsCrashes`. Lets UI tests cover both hang reporting modes.
+public let crashlyticsHangsAsNonFatalsKey = "CRASHLYTICS_HANGS_AS_NONFATALS"
+/// Seconds to delay a simulated issue (crash/hang) after it is triggered. UI tests set this so
+/// they can tap the trigger, send the app to the background, and have the issue happen *while
+/// backgrounded*.
+public let actionDelayKey = "ACTION_DELAY"
 
 
 /// Message which is sent from the app to UI tests target

--- a/PerformanceSuite/UITests/CrashlyticsTests.swift
+++ b/PerformanceSuite/UITests/CrashlyticsTests.swift
@@ -1,0 +1,171 @@
+//
+//  CrashlyticsTests.swift
+//  PerformanceSuite-UI-UITests
+//
+//  UI tests for the real Firebase Crashlytics integration (`enableWithCrashlyticsSupport`),
+//  booted via the `CRASHLYTICS` launch argument.
+//
+//  Invariants under test:
+//   - A real crash IS reported as `.crash` on the next launch
+//     (`didCrashDuringPreviousExecution()` is true), foreground or background.
+//   - A foreground hang is reported as the hang it is (`.fatalHang` / `.nonFatalHang`, in either
+//     reporting mode) and NEVER as a crash on the next launch. Recording the on-demand hang report
+//     writes Firebase's `previously-crashed` marker; if it is not cleared the next launch would
+//     report a phantom `.crash`.
+//   - A hang that happens entirely in the background is intentionally NOT detected (it is not a
+//     user-visible hang), so it is reported as neither a hang nor a crash.
+//
+
+import XCTest
+
+final class CrashlyticsTests: BaseTests {
+
+    // MARK: - Real crash: must be reported as a crash on the next launch
+
+    func testCrash_Foreground_IsReportedAsCrash() {
+        launchClean(inBackground: false)
+        triggerAndBackground("Crash", inBackground: false)
+        waitForTimeout(2)  // crash happens
+        relaunch()
+        waitForMessage { $0 == .crash }
+        assertHasMessages(.crash)
+    }
+
+    func testCrash_Background_IsReportedAsCrash() {
+        launchClean(inBackground: true)
+        triggerAndBackground("Crash", inBackground: true)
+        waitForTimeout(6)  // delayed crash happens while backgrounded
+        relaunch()
+        waitForMessage { $0 == .crash }
+        assertHasMessages(.crash)
+    }
+
+    // MARK: - Fatal hang: reported as a fatal hang, never as a crash (both reporting modes)
+
+    func testFatalHang_Foreground_FatalHangsAsCrashes() {
+        runFatalHang(hangsAsNonFatals: false)
+        waitForMessage { $0 == .fatalHang }
+        assertHasMessages(.fatalHang)
+        assertNoMessages(.crash)
+    }
+
+    func testFatalHang_Foreground_FatalHangsAsNonFatals() {
+        runFatalHang(hangsAsNonFatals: true)
+        waitForMessage { $0 == .fatalHang }
+        assertHasMessages(.fatalHang)
+        assertNoMessages(.crash)
+    }
+
+    // A fatal hang that happens entirely in the background is not detected as a hang (it surfaces,
+    // if at all, as a background watchdog termination); either way it must not be reported as a crash.
+    func testFatalHang_Background_FatalHangsAsCrashes() {
+        runBackgroundHang(menuItem: "Fatal hang", hangsAsNonFatals: false)
+        assertNoMessages(.fatalHang)
+        assertNoMessages(.crash)
+    }
+
+    func testFatalHang_Background_FatalHangsAsNonFatals() {
+        runBackgroundHang(menuItem: "Fatal hang", hangsAsNonFatals: true)
+        assertNoMessages(.fatalHang)
+        assertNoMessages(.crash)
+    }
+
+    // MARK: - Recovered non-fatal hang: reported as non-fatal, never as a crash (both modes)
+
+    func testNonFatalHang_Foreground_FatalHangsAsCrashes() {
+        runRecoveredNonFatalHang(hangsAsNonFatals: false)
+        waitForMessage { $0 == .nonFatalHang }
+        assertHasMessages(.nonFatalHang)
+        assertNoMessages(.crash)
+    }
+
+    func testNonFatalHang_Foreground_FatalHangsAsNonFatals() {
+        runRecoveredNonFatalHang(hangsAsNonFatals: true)
+        waitForMessage { $0 == .nonFatalHang }
+        assertHasMessages(.nonFatalHang)
+        assertNoMessages(.crash)
+    }
+
+    // A hang that happens entirely in the background is intentionally NOT detected by
+    // PerformanceSuite (it is not a user-visible hang), so it is reported neither as a hang nor as
+    // a crash.
+    func testNonFatalHang_Background_FatalHangsAsCrashes() {
+        runBackgroundHang(menuItem: "Non-fatal hang", hangsAsNonFatals: false)
+        assertNoMessages(.nonFatalHang)
+        assertNoMessages(.crash)
+    }
+
+    func testNonFatalHang_Background_FatalHangsAsNonFatals() {
+        runBackgroundHang(menuItem: "Non-fatal hang", hangsAsNonFatals: true)
+        assertNoMessages(.nonFatalHang)
+        assertNoMessages(.crash)
+    }
+
+    // MARK: - Helpers
+
+    private func env(clearStorage: Bool, inBackground: Bool, hangsAsNonFatals: Bool) -> [String: String] {
+        var env = [inTestsKey: "1", crashlyticsKey: "1"]
+        if clearStorage { env[clearStorageKey] = "1" }
+        if hangsAsNonFatals { env[crashlyticsHangsAsNonFatalsKey] = "1" }
+        // When backgrounding, delay the simulated issue so it happens after we go to the background.
+        if inBackground { env[actionDelayKey] = "3" }
+        return env
+    }
+
+    private func launchClean(inBackground: Bool, hangsAsNonFatals: Bool = false) {
+        app.launchEnvironment = env(clearStorage: true, inBackground: inBackground, hangsAsNonFatals: hangsAsNonFatals)
+        app.launch()
+    }
+
+    private func triggerAndBackground(_ menuItem: String, inBackground: Bool) {
+        app.staticTexts[menuItem].tap()
+        if inBackground {
+            // The action is delayed (ACTION_DELAY); background now so it happens while backgrounded.
+            XCUIDevice.shared.press(.home)
+        }
+    }
+
+    /// Relaunch in Crashlytics mode (no storage clear) so we can observe what the previous run left
+    /// behind - in particular whether Crashlytics thinks the app crashed.
+    private func relaunch(hangsAsNonFatals: Bool = false) {
+        app.launchEnvironment = env(clearStorage: false, inBackground: false, hangsAsNonFatals: hangsAsNonFatals)
+        app.launch()
+        waitForTimeout(3)
+    }
+
+    /// Foreground fatal hang: detected (`reportHangStarted` records it per the reporting mode), the
+    /// app never recovers, so we kill it and relaunch.
+    private func runFatalHang(hangsAsNonFatals: Bool) {
+        app.launchEnvironment = env(clearStorage: true, inBackground: false, hangsAsNonFatals: hangsAsNonFatals)
+        app.launch()
+        app.staticTexts["Fatal hang"].tap()
+        waitForTimeout(4)  // let the fatal hang be detected in the foreground
+        app.terminate()    // simulate the system killing the stuck app
+        relaunch(hangsAsNonFatals: hangsAsNonFatals)
+    }
+
+    /// Foreground non-fatal hang: detected, then recovers (this is the path that records and then
+    /// clears the on-demand report/marker).
+    private func runRecoveredNonFatalHang(hangsAsNonFatals: Bool) {
+        app.launchEnvironment = env(clearStorage: true, inBackground: false, hangsAsNonFatals: hangsAsNonFatals)
+        app.launch()
+        app.staticTexts["Non-fatal hang"].tap()
+        // The hang lasts ~6s and then recovers; give the deferred Crashlytics work time to settle.
+        waitForTimeout(10)
+        app.terminate()
+        relaunch(hangsAsNonFatals: hangsAsNonFatals)
+    }
+
+    /// Hang entirely in the background: the action is delayed, we go to the background first, and
+    /// the hang happens there. PerformanceSuite intentionally does not detect background hangs, so
+    /// nothing should be reported (and certainly not a crash on the next launch).
+    private func runBackgroundHang(menuItem: String, hangsAsNonFatals: Bool) {
+        app.launchEnvironment = env(clearStorage: true, inBackground: true, hangsAsNonFatals: hangsAsNonFatals)
+        app.launch()
+        app.staticTexts[menuItem].tap()
+        XCUIDevice.shared.press(.home)  // background before the delayed hang fires
+        waitForTimeout(12)              // hang occurs (and, if non-fatal, recovers) while backgrounded
+        app.terminate()
+        relaunch(hangsAsNonFatals: hangsAsNonFatals)
+    }
+}

--- a/PerformanceSuite/UITests/CrashlyticsTests.swift
+++ b/PerformanceSuite/UITests/CrashlyticsTests.swift
@@ -139,8 +139,10 @@ final class CrashlyticsTests: BaseTests {
         app.launchEnvironment = env(clearStorage: true, inBackground: false, hangsAsNonFatals: hangsAsNonFatals)
         app.launch()
         app.staticTexts["Fatal hang"].tap()
-        waitForTimeout(4)  // let the fatal hang be detected in the foreground
-        app.terminate()    // simulate the system killing the stuck app
+        // Wait until the hang is actually detected before killing the app - a fixed sleep is racy on
+        // slow CI runners (kill too early -> no fatal hang recorded -> the relaunch assertion times out).
+        waitForMessage { $0 == .hangStarted }
+        app.terminate()  // simulate the system killing the stuck app
         relaunch(hangsAsNonFatals: hangsAsNonFatals)
     }
 
@@ -150,8 +152,10 @@ final class CrashlyticsTests: BaseTests {
         app.launchEnvironment = env(clearStorage: true, inBackground: false, hangsAsNonFatals: hangsAsNonFatals)
         app.launch()
         app.staticTexts["Non-fatal hang"].tap()
-        // The hang lasts ~6s and then recovers; give the deferred Crashlytics work time to settle.
-        waitForTimeout(10)
+        // Wait until the recovered hang has actually been reported before killing the app - a fixed
+        // sleep is racy on slow CI runners (kill before the report is captured -> the relaunch
+        // assertion times out).
+        waitForMessage { $0 == .nonFatalHang }
         app.terminate()
         relaunch(hangsAsNonFatals: hangsAsNonFatals)
     }


### PR DESCRIPTION
Adds the first real **Firebase Crashlytics** UI-test coverage to the demo app.

### What
- A `CRASHLYTICS` launch arg boots the demo through `enableWithCrashlyticsSupport` (real Firebase Crashlytics) instead of the lightweight custom crash interceptor.
- An `ACTION_DELAY` launch arg lets a simulated issue happen *fully in the background* (delay the action → home → it fires backgrounded).
- `AppDelegate` imports the Crashlytics support via `#if canImport` (`PerformanceSuiteCrashlytics` in SwiftPM; merged into `PerformanceSuite` under CocoaPods).
- New `CrashlyticsTests` suite:

| Scenario | Foreground | Fully backgrounded |
|---|---|---|
| Real crash | `.crash` reported next launch | `.crash` reported next launch |
| Fatal hang (`fatalHangsAsCrashes`) | `.fatalHang`, no `.crash` | not detected → no hang, no `.crash` |
| Fatal hang (`fatalHangsAsNonFatals`) | `.fatalHang`, no `.crash` | not detected → no hang, no `.crash` |
| Non-fatal hang (`fatalHangsAsCrashes`) | `.nonFatalHang`, no `.crash` | not detected → no hang, no `.crash` |
| Non-fatal hang (`fatalHangsAsNonFatals`) | `.nonFatalHang`, no `.crash` | not detected → no hang, no `.crash` |

### Invariants asserted
1. A **real crash is reported as a crash** on the next launch (`didCrashDuringPreviousExecution()`), foreground or background.
2. A **foreground hang** is reported as the hang it is (`.fatalHang` / `.nonFatalHang`) and **never as a crash** — i.e. the on-demand `previously-crashed` marker is always cleared — in both reporting modes.
3. A **fully-backgrounded hang is intentionally not detected** (not a user-visible hang), so it is reported as neither a hang nor a crash.

### Relationship to the marker-race fix (#48)
These are **coverage**, not a failing reproduction of that race. The deferred-record marker race only manifests under a heavy host app where Firebase's promise observers run out of order; the demo (like the unit tests) runs them in order, so it passes with or without #48. They guard the integration's invariants going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)