### PR TITLE
Release the TTI live span on every abandon path

### DIFF
--- a/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
@@ -19,6 +19,7 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
         self.metricsReceiver = metricsReceiver
         self.timeProvider = timeProvider
         self.appStateListener = appStateListener
+        registerAppLifecycleObserver()
     }
 
     private let screen: T.ScreenIdentifier
@@ -38,8 +39,28 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     private var customCreationTime: DispatchTime?
 
     /// Live measurement handle from `screenTTIMeasurementStarted`, held on `PerformanceMonitoring.queue`. Handed back
-    /// at `screenTTIMeasurementEnded`; cancelled on any abandon path (ignoreThisScreen, negative TTI, deinit).
+    /// at `screenTTIMeasurementEnded`; cancelled on every abandon path — `ignoreThisScreen`, negative TTI/TTFR,
+    /// a disappear that can never produce a metric, `willResignActive`, and `deinit`. The invariant that matters:
+    /// no code path may leave this non-nil, or the span is left for backend auto-termination.
     private var measurementHandle: (any MeasurementHandle)?
+
+    /// Guards the swizzler's lifecycle asymmetry: `viewWillAppear`/`viewDidAppear` are deferred through
+    /// `main.async` while `viewWillDisappear` is called directly, so on a same-turn push-then-pop the
+    /// disappear is processed first and `viewDidAppearTime` is still nil even though the screen did appear.
+    /// Without this, `processDisappear` would read that nil as "never appeared" and abandon a measurable
+    /// screen. Mirrors `RenderingObserver`. Set/read only on `PerformanceMonitoring.queue`.
+    private var didAppearProcessed = false
+    private var pendingDisappear = false
+
+    /// `TTIObserverHelper.upcomingCustomCreationTime` is a process-global set just before this screen was
+    /// created, so it must be consumed exactly once by our first `viewWillAppear` — even when the measurement
+    /// is already abandoned. Leaving it set strands it for whichever screen appears next, which would then
+    /// report a TTI anchored before its own `init`.
+    private var consumedCustomCreationTime = false
+
+    /// Block-based app-lifecycle observer (`TTIObserver` is generic, so it cannot expose @objc selectors).
+    /// Removed in `deinit`.
+    private var lifecycleObserver: (any NSObjectProtocol)?
 
     func beforeInit() {
         let now = timeProvider.now()
@@ -101,10 +122,19 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.cancelMeasurement()
             }
 
-            if self.shouldReportTTI && self.viewWillAppearTime == nil {
-                self.customCreationTime = TTIObserverHelper.upcomingCustomCreationTime
+            if !self.consumedCustomCreationTime {
+                // Consume the global on our first viewWillAppear whether or not a metric is still permitted:
+                // it was set for *this* screen, and an abandoned screen that leaves it set corrupts the next
+                // screen's TTI. Only the assignment is gated.
+                self.consumedCustomCreationTime = true
+                let upcoming = TTIObserverHelper.upcomingCustomCreationTime
                 TTIObserverHelper.upcomingCustomCreationTime = nil
+                if self.shouldReportTTI {
+                    self.customCreationTime = upcoming
+                }
+            }
 
+            if self.shouldReportTTI && self.viewWillAppearTime == nil {
                 self.viewWillAppearTime = now
             }
         }
@@ -120,6 +150,14 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.viewDidAppearTime = now
                 self.reportTTIIfNeeded()
             }
+            // Set unconditionally: `processDisappear` must distinguish "appear has not drained yet" from
+            // "this screen never appeared", and that distinction holds whether or not a metric is permitted.
+            self.didAppearProcessed = true
+            // A same-turn push-then-pop queued the disappear ahead of this closure — finish it now.
+            if self.pendingDisappear {
+                self.pendingDisappear = false
+                self.processDisappear()
+            }
         }
 
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
@@ -127,16 +165,45 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     }
 
     func beforeViewWillDisappear() {
-        // if screenIsReady wasn't called until now, we consider that screen was ready in `viewDidAppear`.
         let action = {
-            if self.shouldReportTTI && self.screenIsReadyTime == nil {
-                self.screenIsReadyTime = self.viewDidAppearTime
-                self.reportTTIIfNeeded()
+            guard self.didAppearProcessed else {
+                // didAppear's closure has not run yet (see `didAppearProcessed`). Park, and let
+                // `afterViewDidAppear` replay this once the timestamps exist. Parking cannot leak the span:
+                // a screen that truly never appears never reaches `afterViewDidAppear`, and its span is
+                // released by `handleWillResignActive` or `deinit`.
+                self.pendingDisappear = true
+                return
             }
+            self.processDisappear()
         }
 
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
         action()
+    }
+
+    private func processDisappear() {
+        dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
+
+        guard shouldReportTTI else {
+            // No metric is permitted and none ever will be (`wasInBackground` latched, or
+            // `ignoreThisScreen`). Release the live span instead of returning silently.
+            cancelMeasurement()
+            return
+        }
+        // Reached only once didAppear has been processed, so a nil `viewDidAppearTime` here really does mean
+        // the screen never appeared — e.g. a container that touched `view` on an off-screen child.
+        guard viewDidAppearTime != nil else {
+            // `reportTTIIfNeeded` can never be satisfied. Latch the screen out so a late `screenIsReady()`
+            // cannot resurrect a cancelled measurement, and release the span.
+            ignoreThisScreen = true
+            cancelMeasurement()
+            return
+        }
+        if screenIsReadyTime == nil {
+            // if screenIsReady wasn't called until now, we consider that screen was ready in `viewDidAppear`.
+            screenIsReadyTime = viewDidAppearTime
+        }
+        reportTTIIfNeeded()
     }
 
     static var identifier: AnyObject {
@@ -203,9 +270,38 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
         return !ttiCalculated && !appStateListener.wasInBackground && !ignoreThisScreen
     }
 
-    /// Cancel and clear the open live measurement. Called from every path that abandons the
-    /// measurement: `ignoreThisScreen` (double-viewWillAppear), negative TTI/TTFR
-    /// assertion, and `deinit` (observer destroyed before `reportTTIIfNeeded` ran). Idempotent.
+    /// A TTI span opens in `beforeViewDidLoad` and closes only when TTI resolves, so it can straddle an app
+    /// background. Backgrounding fires no `viewWillDisappear`, so without this the span stays open and is
+    /// auto-terminated by the backend (e.g. Embrace, `user_abandon`). Cancel synchronously on
+    /// `willResignActive`, which precedes the backend's `didEnterBackground` session end.
+    ///
+    /// Unlike `RenderingObserver` there is no `didBecomeActive` restart: TTI is one-shot, and once
+    /// `wasInBackground` latches `shouldReportTTI` would reject a restarted measurement anyway.
+    private func registerAppLifecycleObserver() {
+        lifecycleObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.willResignActiveNotification, object: nil, queue: nil
+        ) { [weak self] _ in
+            self?.handleWillResignActive()
+        }
+    }
+
+    private func handleWillResignActive() {
+        // Synchronous so the span closes inside this notification turn, before the backend ends the session.
+        //
+        // Deliberately NOT gated on `shouldReportTTI`: `DefaultAppStateListener` registers its own
+        // `willResignActive` observer in its `init`, which runs as this observer's default argument and is
+        // therefore always registered first. `wasInBackground` is already true by the time we run, so a
+        // gated version of this would be dead code.
+        PerformanceMonitoring.runOnQueue {
+            self.ignoreThisScreen = true
+            self.cancelMeasurement()
+        }
+    }
+
+    /// Cancel and clear the open live measurement. Called from every path that abandons the measurement:
+    /// `ignoreThisScreen` (double-viewWillAppear), negative TTI/TTFR assertion, a `viewWillDisappear` that
+    /// can never produce a metric (backgrounded, or the screen never appeared), `willResignActive`, and
+    /// `deinit` (observer destroyed before `reportTTIIfNeeded` ran). Idempotent.
     private func cancelMeasurement() {
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
         if let context = self.measurementHandle {
@@ -215,6 +311,9 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     }
 
     deinit {
+        if let lifecycleObserver {
+            NotificationCenter.default.removeObserver(lifecycleObserver)
+        }
         // VC went away before TTI completed: discard any open measurement. measurementHandle is mutated only on
         // PerformanceMonitoring.queue and queued closures retain self, so deinit runs only after
         // that work drains — direct access is race-free.

--- a/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
@@ -19,7 +19,9 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
         self.metricsReceiver = metricsReceiver
         self.timeProvider = timeProvider
         self.appStateListener = appStateListener
-        registerAppLifecycleObserver()
+        appStateListener.didChange = { [weak self] in
+            self?.handleAppStateChange()
+        }
     }
 
     private let screen: T.ScreenIdentifier
@@ -38,24 +40,9 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
 
     private var customCreationTime: DispatchTime?
 
-    /// Live measurement handle from `screenTTIMeasurementStarted`, held on `PerformanceMonitoring.queue`. Handed
-    /// back at `screenTTIMeasurementEnded`. No path may leave it non-nil, or the span is left open for the
-    /// backend to auto-terminate.
+    /// Live measurement handle from `screenTTIMeasurementStarted`, held on `PerformanceMonitoring.queue`. Handed back
+    /// at `screenTTIMeasurementEnded`; cancelled on any abandon path (ignoreThisScreen, negative TTI, deinit).
     private var measurementHandle: (any MeasurementHandle)?
-
-    /// The swizzler defers `viewWillAppear`/`viewDidAppear` through `main.async` but calls
-    /// `viewWillDisappear` directly, so a same-turn push-then-pop lands the disappear first. Mirrors
-    /// `RenderingObserver`. Set/read only on `PerformanceMonitoring.queue`.
-    private var didAppearProcessed = false
-    private var pendingDisappear = false
-
-    /// `upcomingCustomCreationTime` is a process-global. An abandoned screen that leaves it set strands it
-    /// for the next screen, which then reports a TTI anchored before its own `init`.
-    private var consumedCustomCreationTime = false
-
-    /// Block-based app-lifecycle observer (`TTIObserver` is generic, so it cannot expose @objc selectors).
-    /// Removed in `deinit`.
-    private var lifecycleObserver: (any NSObjectProtocol)?
 
     func beforeInit() {
         let now = timeProvider.now()
@@ -117,17 +104,10 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.cancelMeasurement()
             }
 
-            // Consumed whether or not a metric is still permitted; only the assignment is gated.
-            if !self.consumedCustomCreationTime {
-                self.consumedCustomCreationTime = true
-                let upcoming = TTIObserverHelper.upcomingCustomCreationTime
-                TTIObserverHelper.upcomingCustomCreationTime = nil
-                if self.shouldReportTTI {
-                    self.customCreationTime = upcoming
-                }
-            }
-
             if self.shouldReportTTI && self.viewWillAppearTime == nil {
+                self.customCreationTime = TTIObserverHelper.upcomingCustomCreationTime
+                TTIObserverHelper.upcomingCustomCreationTime = nil
+
                 self.viewWillAppearTime = now
             }
         }
@@ -143,12 +123,6 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.viewDidAppearTime = now
                 self.reportTTIIfNeeded()
             }
-            // Unconditional: `processDisappear` distinguishes "not drained yet" from "never appeared".
-            self.didAppearProcessed = true
-            if self.pendingDisappear {
-                self.pendingDisappear = false
-                self.processDisappear()
-            }
         }
 
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
@@ -156,41 +130,16 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     }
 
     func beforeViewWillDisappear() {
+        // if screenIsReady wasn't called until now, we consider that screen was ready in `viewDidAppear`.
         let action = {
-            guard self.didAppearProcessed else {
-                // Replayed from `afterViewDidAppear`. A screen that truly never appears never gets there, and
-                // its span is released by `handleWillResignActive` or `deinit` instead.
-                self.pendingDisappear = true
-                return
+            if self.shouldReportTTI && self.screenIsReadyTime == nil {
+                self.screenIsReadyTime = self.viewDidAppearTime
+                self.reportTTIIfNeeded()
             }
-            self.processDisappear()
         }
 
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
         action()
-    }
-
-    private func processDisappear() {
-        dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
-
-        // No metric is permitted and none ever will be.
-        guard shouldReportTTI else {
-            cancelMeasurement()
-            return
-        }
-        // didAppear has been processed, so nil here really does mean the screen never appeared — e.g. a
-        // container that touched `view` on an off-screen child. Latched so a late `screenIsReady()` cannot
-        // resurrect the cancelled measurement.
-        guard viewDidAppearTime != nil else {
-            ignoreThisScreen = true
-            cancelMeasurement()
-            return
-        }
-        if screenIsReadyTime == nil {
-            // if screenIsReady wasn't called until now, we consider that screen was ready in `viewDidAppear`.
-            screenIsReadyTime = viewDidAppearTime
-        }
-        reportTTIIfNeeded()
     }
 
     static var identifier: AnyObject {
@@ -257,27 +206,22 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
         return !ttiCalculated && !appStateListener.wasInBackground && !ignoreThisScreen
     }
 
-    /// Backgrounding fires no `viewWillDisappear`, so without this an unresolved span is left for the backend
-    /// to auto-terminate. No `didBecomeActive` restart, unlike `RenderingObserver`: TTI is one-shot.
-    private func registerAppLifecycleObserver() {
-        lifecycleObserver = NotificationCenter.default.addObserver(
-            forName: UIApplication.willResignActiveNotification, object: nil, queue: nil
-        ) { [weak self] _ in
-            self?.handleWillResignActive()
-        }
+    /// Backgrounding fires no `viewWillDisappear`, so an unresolved measurement would otherwise leave its live
+    /// span open for the backend to auto-terminate. `didChange` fires for resign-active and become-active
+    /// alike; once `wasInBackground` has latched the measurement can never report either way. No restart,
+    /// unlike `RenderingObserver`: TTI is one-shot.
+    private func handleAppStateChange() {
+        dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
+        guard appStateListener.wasInBackground else { return }
+        // `ignoreThisScreen` keeps a re-entrant `beforeViewDidLoad` from opening a second span now that the
+        // handle is nil.
+        ignoreThisScreen = true
+        cancelMeasurement()
     }
 
-    private func handleWillResignActive() {
-        // Synchronous, so the span closes before the backend ends the session. Deliberately not gated on
-        // `shouldReportTTI`: `DefaultAppStateListener` registers its observer in an `init` that runs as this
-        // observer's default argument, so `wasInBackground` is already true here and a gate would be dead code.
-        PerformanceMonitoring.runOnQueue {
-            self.ignoreThisScreen = true
-            self.cancelMeasurement()
-        }
-    }
-
-    /// Cancel and clear the open live measurement. Called from every abandon path. Idempotent.
+    /// Cancel and clear the open live measurement. Called from every path that abandons the
+    /// measurement: `ignoreThisScreen` (double-viewWillAppear), negative TTI/TTFR
+    /// assertion, and `deinit` (observer destroyed before `reportTTIIfNeeded` ran). Idempotent.
     private func cancelMeasurement() {
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
         if let context = self.measurementHandle {
@@ -287,9 +231,6 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     }
 
     deinit {
-        if let lifecycleObserver {
-            NotificationCenter.default.removeObserver(lifecycleObserver)
-        }
         // VC went away before TTI completed: discard any open measurement. measurementHandle is mutated only on
         // PerformanceMonitoring.queue and queued closures retain self, so deinit runs only after
         // that work drains — direct access is race-free.

--- a/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
@@ -38,24 +38,19 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
 
     private var customCreationTime: DispatchTime?
 
-    /// Live measurement handle from `screenTTIMeasurementStarted`, held on `PerformanceMonitoring.queue`. Handed back
-    /// at `screenTTIMeasurementEnded`; cancelled on every abandon path — `ignoreThisScreen`, negative TTI/TTFR,
-    /// a disappear that can never produce a metric, `willResignActive`, and `deinit`. The invariant that matters:
-    /// no code path may leave this non-nil, or the span is left for backend auto-termination.
+    /// Live measurement handle from `screenTTIMeasurementStarted`, held on `PerformanceMonitoring.queue`. Handed
+    /// back at `screenTTIMeasurementEnded`. No path may leave it non-nil, or the span is left open for the
+    /// backend to auto-terminate.
     private var measurementHandle: (any MeasurementHandle)?
 
-    /// Guards the swizzler's lifecycle asymmetry: `viewWillAppear`/`viewDidAppear` are deferred through
-    /// `main.async` while `viewWillDisappear` is called directly, so on a same-turn push-then-pop the
-    /// disappear is processed first and `viewDidAppearTime` is still nil even though the screen did appear.
-    /// Without this, `processDisappear` would read that nil as "never appeared" and abandon a measurable
-    /// screen. Mirrors `RenderingObserver`. Set/read only on `PerformanceMonitoring.queue`.
+    /// The swizzler defers `viewWillAppear`/`viewDidAppear` through `main.async` but calls
+    /// `viewWillDisappear` directly, so a same-turn push-then-pop lands the disappear first. Mirrors
+    /// `RenderingObserver`. Set/read only on `PerformanceMonitoring.queue`.
     private var didAppearProcessed = false
     private var pendingDisappear = false
 
-    /// `TTIObserverHelper.upcomingCustomCreationTime` is a process-global set just before this screen was
-    /// created, so it must be consumed exactly once by our first `viewWillAppear` — even when the measurement
-    /// is already abandoned. Leaving it set strands it for whichever screen appears next, which would then
-    /// report a TTI anchored before its own `init`.
+    /// `upcomingCustomCreationTime` is a process-global. An abandoned screen that leaves it set strands it
+    /// for the next screen, which then reports a TTI anchored before its own `init`.
     private var consumedCustomCreationTime = false
 
     /// Block-based app-lifecycle observer (`TTIObserver` is generic, so it cannot expose @objc selectors).
@@ -122,10 +117,8 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.cancelMeasurement()
             }
 
+            // Consumed whether or not a metric is still permitted; only the assignment is gated.
             if !self.consumedCustomCreationTime {
-                // Consume the global on our first viewWillAppear whether or not a metric is still permitted:
-                // it was set for *this* screen, and an abandoned screen that leaves it set corrupts the next
-                // screen's TTI. Only the assignment is gated.
                 self.consumedCustomCreationTime = true
                 let upcoming = TTIObserverHelper.upcomingCustomCreationTime
                 TTIObserverHelper.upcomingCustomCreationTime = nil
@@ -150,10 +143,8 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.viewDidAppearTime = now
                 self.reportTTIIfNeeded()
             }
-            // Set unconditionally: `processDisappear` must distinguish "appear has not drained yet" from
-            // "this screen never appeared", and that distinction holds whether or not a metric is permitted.
+            // Unconditional: `processDisappear` distinguishes "not drained yet" from "never appeared".
             self.didAppearProcessed = true
-            // A same-turn push-then-pop queued the disappear ahead of this closure — finish it now.
             if self.pendingDisappear {
                 self.pendingDisappear = false
                 self.processDisappear()
@@ -167,10 +158,8 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     func beforeViewWillDisappear() {
         let action = {
             guard self.didAppearProcessed else {
-                // didAppear's closure has not run yet (see `didAppearProcessed`). Park, and let
-                // `afterViewDidAppear` replay this once the timestamps exist. Parking cannot leak the span:
-                // a screen that truly never appears never reaches `afterViewDidAppear`, and its span is
-                // released by `handleWillResignActive` or `deinit`.
+                // Replayed from `afterViewDidAppear`. A screen that truly never appears never gets there, and
+                // its span is released by `handleWillResignActive` or `deinit` instead.
                 self.pendingDisappear = true
                 return
             }
@@ -184,17 +173,15 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     private func processDisappear() {
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
 
+        // No metric is permitted and none ever will be.
         guard shouldReportTTI else {
-            // No metric is permitted and none ever will be (`wasInBackground` latched, or
-            // `ignoreThisScreen`). Release the live span instead of returning silently.
             cancelMeasurement()
             return
         }
-        // Reached only once didAppear has been processed, so a nil `viewDidAppearTime` here really does mean
-        // the screen never appeared — e.g. a container that touched `view` on an off-screen child.
+        // didAppear has been processed, so nil here really does mean the screen never appeared — e.g. a
+        // container that touched `view` on an off-screen child. Latched so a late `screenIsReady()` cannot
+        // resurrect the cancelled measurement.
         guard viewDidAppearTime != nil else {
-            // `reportTTIIfNeeded` can never be satisfied. Latch the screen out so a late `screenIsReady()`
-            // cannot resurrect a cancelled measurement, and release the span.
             ignoreThisScreen = true
             cancelMeasurement()
             return
@@ -270,13 +257,8 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
         return !ttiCalculated && !appStateListener.wasInBackground && !ignoreThisScreen
     }
 
-    /// A TTI span opens in `beforeViewDidLoad` and closes only when TTI resolves, so it can straddle an app
-    /// background. Backgrounding fires no `viewWillDisappear`, so without this the span stays open and is
-    /// auto-terminated by the backend (e.g. Embrace, `user_abandon`). Cancel synchronously on
-    /// `willResignActive`, which precedes the backend's `didEnterBackground` session end.
-    ///
-    /// Unlike `RenderingObserver` there is no `didBecomeActive` restart: TTI is one-shot, and once
-    /// `wasInBackground` latches `shouldReportTTI` would reject a restarted measurement anyway.
+    /// Backgrounding fires no `viewWillDisappear`, so without this an unresolved span is left for the backend
+    /// to auto-terminate. No `didBecomeActive` restart, unlike `RenderingObserver`: TTI is one-shot.
     private func registerAppLifecycleObserver() {
         lifecycleObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.willResignActiveNotification, object: nil, queue: nil
@@ -286,22 +268,16 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
     }
 
     private func handleWillResignActive() {
-        // Synchronous so the span closes inside this notification turn, before the backend ends the session.
-        //
-        // Deliberately NOT gated on `shouldReportTTI`: `DefaultAppStateListener` registers its own
-        // `willResignActive` observer in its `init`, which runs as this observer's default argument and is
-        // therefore always registered first. `wasInBackground` is already true by the time we run, so a
-        // gated version of this would be dead code.
+        // Synchronous, so the span closes before the backend ends the session. Deliberately not gated on
+        // `shouldReportTTI`: `DefaultAppStateListener` registers its observer in an `init` that runs as this
+        // observer's default argument, so `wasInBackground` is already true here and a gate would be dead code.
         PerformanceMonitoring.runOnQueue {
             self.ignoreThisScreen = true
             self.cancelMeasurement()
         }
     }
 
-    /// Cancel and clear the open live measurement. Called from every path that abandons the measurement:
-    /// `ignoreThisScreen` (double-viewWillAppear), negative TTI/TTFR assertion, a `viewWillDisappear` that
-    /// can never produce a metric (backgrounded, or the screen never appeared), `willResignActive`, and
-    /// `deinit` (observer destroyed before `reportTTIIfNeeded` ran). Idempotent.
+    /// Cancel and clear the open live measurement. Called from every abandon path. Idempotent.
     private func cancelMeasurement() {
         dispatchPrecondition(condition: .onQueue(PerformanceMonitoring.queue))
         if let context = self.measurementHandle {

--- a/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
+++ b/PerformanceSuite/Sources/InstanceObservers/TTIObserver.swift
@@ -104,7 +104,10 @@ final class TTIObserver<T: TTIMetricsReceiver>: ViewControllerInstanceObserver, 
                 self.cancelMeasurement()
             }
 
-            if self.shouldReportTTI && self.viewWillAppearTime == nil {
+            // Not gated on `shouldReportTTI`: the anchor was set for *this* screen, so an abandoned screen
+            // must still consume it or it strands and the next screen reports a TTI predating its own init.
+            // `testCustomCreationTimeIsForgotten` already pins that for a screen that reported.
+            if self.viewWillAppearTime == nil {
                 self.customCreationTime = TTIObserverHelper.upcomingCustomCreationTime
                 TTIObserverHelper.upcomingCustomCreationTime = nil
 

--- a/PerformanceSuite/Tests/TTIObserverTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverTests.swift
@@ -508,172 +508,114 @@ class TTIObserverTests: XCTestCase {
     // A *live* receiver is required: `TTIMetricsReceiverStub` is not live and `TTIObserver` resolves the live
     // receiver by conditional cast, so tests using it pin nothing about the measurement handle.
 
-    func testLiveSpanIsCancelledOnWillResignActiveWhenScreenNeverAppeared() {
+    func testLiveSpanIsReleasedOnBackgroundWhenScreenNeverAppeared() {
         // A force-loaded off-screen child never appears and gets no disappear, so backgrounding is the only
         // signal left.
+        let appState = AppStateListenerStub()
         let metricsReceiver = LiveTTIMetricsReceiverStub()
-        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, appStateListener: appState)
 
         observer.beforeInit()
         observer.beforeViewDidLoad()
         XCTAssertEqual(metricsReceiver.startedContexts.count, 1, "viewDidLoad must open one live span")
 
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        PerformanceMonitoring.consumerQueue.sync {}
+        appState.wasInBackground = true
+        appState.didChange()
 
         XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1, "span must be released")
         XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
         XCTAssertNil(metricsReceiver.ttiMetrics)
     }
 
-    func testLiveSpanIsCancelledOnWillResignActiveWhenReadinessNeverArrived() {
+    func testLiveSpanIsReleasedOnBackgroundWhenReadinessNeverArrived() {
         // With no readiness call the span resolves only via the disappear fallback, which backgrounding
         // never triggers.
+        let appState = AppStateListenerStub()
         let metricsReceiver = LiveTTIMetricsReceiverStub()
-        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, appStateListener: appState)
 
         observer.beforeInit()
         observer.beforeViewDidLoad()
         observer.afterViewWillAppear()
         observer.afterViewDidAppear()
-        PerformanceMonitoring.consumerQueue.sync {}
-
-        XCTAssertEqual(metricsReceiver.startedContexts.count, 1)
         XCTAssertTrue(metricsReceiver.endedContexts.isEmpty, "no readiness signal yet, so nothing reported")
 
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        PerformanceMonitoring.consumerQueue.sync {}
+        appState.wasInBackground = true
+        appState.didChange()
 
         XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1, "span must be released")
         XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
     }
 
-    func testDisappearBeforeDidAppearIsParkedAndStillReports() {
-        // Same-turn push-then-pop delivers the disappear before the deferred appear callbacks. Reading the
-        // still-nil viewDidAppearTime as "never appeared" would abandon a measurable screen.
-        let timeProvider = TimeProviderStub()
-        let time = timeProvider.time
-
+    func testBecomingActiveWithoutHavingBackgroundedLeavesTheSpanOpen() {
+        // `didChange` also fires for become-active. Nothing may be released until `wasInBackground` latches.
+        let appState = AppStateListenerStub()
         let metricsReceiver = LiveTTIMetricsReceiverStub()
         let observer = TTIObserver(
-            screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+            screen: UIViewController(), metricsReceiver: metricsReceiver, appStateListener: appState)
 
         observer.beforeInit()
         observer.beforeViewDidLoad()
+        appState.didChange()
 
-        timeProvider.time = time.advanced(by: .milliseconds(3))
-        observer.screenIsReady()
-        waitForTheNextRunLoop()
-
-        timeProvider.time = time.advanced(by: .milliseconds(5))
-        observer.beforeViewWillDisappear()   // inverted: lands before the deferred appear callbacks
-
-        timeProvider.time = time.advanced(by: .milliseconds(8))
-        observer.afterViewWillAppear()
-
-        timeProvider.time = time.advanced(by: .milliseconds(10))
-        observer.afterViewDidAppear()
-        PerformanceMonitoring.consumerQueue.sync {}
-
-        XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "parked disappear must be replayed and reported")
-        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not abandon the screen")
-        // ttiEndTime is max(readiness, didAppear), so early readiness still yields 10ms.
-        XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
-        XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not release a live span")
     }
 
-    func testLiveSpanStillReportsOnDisappearWithoutReadinessCall() {
-        // The supported contract, and how most tracked screens get their TTI at all.
-        let timeProvider = TimeProviderStub()
-        let time = timeProvider.time
-
-        let metricsReceiver = LiveTTIMetricsReceiverStub()
-        let observer = TTIObserver(
-            screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
-
-        observer.beforeInit()
-        observer.beforeViewDidLoad()
-
-        timeProvider.time = time.advanced(by: .milliseconds(8))
-        observer.afterViewWillAppear()
-
-        timeProvider.time = time.advanced(by: .milliseconds(10))
-        observer.afterViewDidAppear()
-
-        timeProvider.time = time.advanced(by: .milliseconds(100))
-        observer.beforeViewWillDisappear()
-        PerformanceMonitoring.consumerQueue.sync {}
-
-        XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "the back-dating fallback must still report")
-        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not cancel a reportable one")
-        XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
-        XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
-    }
-
-    func testCancelledScreenDoesNotOpenASecondSpan() {
-        // A cancel nils `measurementHandle`, satisfying `beforeViewDidLoad`'s guard; only `ignoreThisScreen`
+    func testReleasedScreenDoesNotOpenASecondSpan() {
+        // A release nils `measurementHandle`, satisfying `beforeViewDidLoad`'s guard; only `ignoreThisScreen`
         // stops a second orphaned span.
+        let appState = AppStateListenerStub()
         let metricsReceiver = LiveTTIMetricsReceiverStub()
-        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, appStateListener: appState)
 
         observer.beforeInit()
         observer.beforeViewDidLoad()
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        PerformanceMonitoring.consumerQueue.sync {}
+        appState.wasInBackground = true
+        appState.didChange()
         XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1)
 
         observer.beforeViewDidLoad()
-        PerformanceMonitoring.consumerQueue.sync {}
 
         XCTAssertEqual(metricsReceiver.startedContexts.count, 1, "must not open a second span")
         XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
     }
 
-    func testAbandonedScreenDoesNotStrandCustomCreationTime() {
-        // An abandoned screen that skipped consuming the global would leak it to the next screen.
+    func testLiveSpanStillReportsOnDisappearWithoutReadinessCall() {
+        // Characterisation pin: this leaves `beforeViewWillDisappear` untouched, and it is how most tracked
+        // screens get their TTI at all.
         let timeProvider = TimeProviderStub()
         let time = timeProvider.time
 
-        let receiverA = LiveTTIMetricsReceiverStub()
-        let observerA = TTIObserver(
-            screen: UIViewController(), metricsReceiver: receiverA, timeProvider: timeProvider)
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
 
-        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
         waitForTheNextRunLoop()
 
-        // Abandon A: its own listener latches `wasInBackground`, so it can never report.
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        PerformanceMonitoring.consumerQueue.sync {}
-
-        timeProvider.time = time.advanced(by: .milliseconds(150))
-        observerA.beforeInit()
-        observerA.beforeViewDidLoad()
-        timeProvider.time = time.advanced(by: .milliseconds(200))
-        observerA.afterViewWillAppear()
+        timeProvider.time = time.advanced(by: .milliseconds(8))
+        observer.afterViewWillAppear()
         waitForTheNextRunLoop()
 
-        // B is created after the notification, so its listener never saw it and it reports normally.
-        let receiverB = LiveTTIMetricsReceiverStub()
-        let observerB = TTIObserver(
-            screen: UIViewController(), metricsReceiver: receiverB, timeProvider: timeProvider)
+        timeProvider.time = time.advanced(by: .milliseconds(10))
+        observer.afterViewDidAppear()
+        waitForTheNextRunLoop()
 
-        timeProvider.time = time.advanced(by: .milliseconds(250))
-        observerB.beforeInit()
-        observerB.beforeViewDidLoad()
-        timeProvider.time = time.advanced(by: .milliseconds(300))
-        observerB.afterViewWillAppear()
-        timeProvider.time = time.advanced(by: .milliseconds(320))
-        observerB.afterViewDidAppear()
-        timeProvider.time = time.advanced(by: .milliseconds(400))
-        observerB.screenIsReady()
+        timeProvider.time = time.advanced(by: .milliseconds(100))
+        observer.beforeViewWillDisappear()
         waitForTheNextRunLoop()
         PerformanceMonitoring.consumerQueue.sync {}
 
-        XCTAssertNil(receiverA.ttiMetrics, "the abandoned screen must not report")
-        XCTAssertEqual(
-            receiverB.ttiMetrics?.tti, .milliseconds(150),
-            "B must anchor at its own init (400-250), not A's stranded creation time (400-0)")
+        XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "the disappear fallback must still report")
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not cancel a reportable one")
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
     }
+
 }
 
 class TimeProviderStub: TimeProvider {

--- a/PerformanceSuite/Tests/TTIObserverTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverTests.swift
@@ -505,12 +505,12 @@ class TTIObserverTests: XCTestCase {
 
     // MARK: - Live-measurement lifecycle
     //
-    // These use a *live* receiver deliberately: `TTIMetricsReceiverStub` is not live and `TTIObserver` resolves
-    // the live receiver by conditional cast, so tests using it pin nothing about the measurement handle.
+    // A *live* receiver is required: `TTIMetricsReceiverStub` is not live and `TTIObserver` resolves the live
+    // receiver by conditional cast, so tests using it pin nothing about the measurement handle.
 
     func testLiveSpanIsCancelledOnWillResignActiveWhenScreenNeverAppeared() {
-        // A container touching `view` on an off-screen child forces `viewDidLoad`, opening the span. Such a
-        // screen never appears and receives no disappear, so backgrounding is the only signal left.
+        // A force-loaded off-screen child never appears and gets no disappear, so backgrounding is the only
+        // signal left.
         let metricsReceiver = LiveTTIMetricsReceiverStub()
         let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
 
@@ -527,8 +527,8 @@ class TTIObserverTests: XCTestCase {
     }
 
     func testLiveSpanIsCancelledOnWillResignActiveWhenReadinessNeverArrived() {
-        // No `screenIsReady()` call means the span resolves only via the disappear fallback, and iOS sends no
-        // viewWillDisappear on backgrounding — so without this the span stays open to session end.
+        // With no readiness call the span resolves only via the disappear fallback, which backgrounding
+        // never triggers.
         let metricsReceiver = LiveTTIMetricsReceiverStub()
         let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
 
@@ -549,9 +549,8 @@ class TTIObserverTests: XCTestCase {
     }
 
     func testDisappearBeforeDidAppearIsParkedAndStillReports() {
-        // The swizzler defers viewWillAppear/viewDidAppear via main.async but calls viewWillDisappear directly,
-        // so a same-turn push-then-pop delivers the disappear first. Reading the still-nil viewDidAppearTime as
-        // "never appeared" would abandon a measurable screen; it must be parked and replayed.
+        // Same-turn push-then-pop delivers the disappear before the deferred appear callbacks. Reading the
+        // still-nil viewDidAppearTime as "never appeared" would abandon a measurable screen.
         let timeProvider = TimeProviderStub()
         let time = timeProvider.time
 
@@ -578,14 +577,13 @@ class TTIObserverTests: XCTestCase {
 
         XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "parked disappear must be replayed and reported")
         XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not abandon the screen")
-        // `ttiEndTime` is max(screenIsReadyTime, viewDidAppearTime), so early readiness still yields 10ms.
+        // ttiEndTime is max(readiness, didAppear), so early readiness still yields 10ms.
         XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
         XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
     }
 
     func testLiveSpanStillReportsOnDisappearWithoutReadinessCall() {
-        // The supported contract: appear -> no screenIsReady -> disappear must still report, back-dating
-        // readiness to viewDidAppear. Most tracked screens get their TTI only this way.
+        // The supported contract, and how most tracked screens get their TTI at all.
         let timeProvider = TimeProviderStub()
         let time = timeProvider.time
 
@@ -613,8 +611,8 @@ class TTIObserverTests: XCTestCase {
     }
 
     func testCancelledScreenDoesNotOpenASecondSpan() {
-        // After a cancel `measurementHandle` is nil, so `beforeViewDidLoad`'s `measurementHandle == nil` clause
-        // is satisfied and a re-entrant call would open a second orphaned span. `ignoreThisScreen` blocks it.
+        // A cancel nils `measurementHandle`, satisfying `beforeViewDidLoad`'s guard; only `ignoreThisScreen`
+        // stops a second orphaned span.
         let metricsReceiver = LiveTTIMetricsReceiverStub()
         let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
 
@@ -632,8 +630,7 @@ class TTIObserverTests: XCTestCase {
     }
 
     func testAbandonedScreenDoesNotStrandCustomCreationTime() {
-        // `upcomingCustomCreationTime` is a process-global consumed in `afterViewWillAppear`. If an abandoned
-        // screen skipped that, it would leak to the next screen, which reports a TTI predating its own init.
+        // An abandoned screen that skipped consuming the global would leak it to the next screen.
         let timeProvider = TimeProviderStub()
         let time = timeProvider.time
 

--- a/PerformanceSuite/Tests/TTIObserverTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverTests.swift
@@ -502,6 +502,181 @@ class TTIObserverTests: XCTestCase {
         XCTAssertNil(metricsReceiver.lastController)
         XCTAssertNil(metricsReceiver.ttiMetrics)
     }
+
+    // MARK: - Live-measurement lifecycle
+    //
+    // These use a *live* receiver deliberately: `TTIMetricsReceiverStub` is not live and `TTIObserver` resolves
+    // the live receiver by conditional cast, so tests using it pin nothing about the measurement handle.
+
+    func testLiveSpanIsCancelledOnWillResignActiveWhenScreenNeverAppeared() {
+        // A container touching `view` on an off-screen child forces `viewDidLoad`, opening the span. Such a
+        // screen never appears and receives no disappear, so backgrounding is the only signal left.
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
+        XCTAssertEqual(metricsReceiver.startedContexts.count, 1, "viewDidLoad must open one live span")
+
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1, "span must be released")
+        XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
+        XCTAssertNil(metricsReceiver.ttiMetrics)
+    }
+
+    func testLiveSpanIsCancelledOnWillResignActiveWhenReadinessNeverArrived() {
+        // No `screenIsReady()` call means the span resolves only via the disappear fallback, and iOS sends no
+        // viewWillDisappear on backgrounding — so without this the span stays open to session end.
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
+        observer.afterViewWillAppear()
+        observer.afterViewDidAppear()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedContexts.count, 1)
+        XCTAssertTrue(metricsReceiver.endedContexts.isEmpty, "no readiness signal yet, so nothing reported")
+
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1, "span must be released")
+        XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
+    }
+
+    func testDisappearBeforeDidAppearIsParkedAndStillReports() {
+        // The swizzler defers viewWillAppear/viewDidAppear via main.async but calls viewWillDisappear directly,
+        // so a same-turn push-then-pop delivers the disappear first. Reading the still-nil viewDidAppearTime as
+        // "never appeared" would abandon a measurable screen; it must be parked and replayed.
+        let timeProvider = TimeProviderStub()
+        let time = timeProvider.time
+
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
+
+        timeProvider.time = time.advanced(by: .milliseconds(3))
+        observer.screenIsReady()
+        waitForTheNextRunLoop()
+
+        timeProvider.time = time.advanced(by: .milliseconds(5))
+        observer.beforeViewWillDisappear()   // inverted: lands before the deferred appear callbacks
+
+        timeProvider.time = time.advanced(by: .milliseconds(8))
+        observer.afterViewWillAppear()
+
+        timeProvider.time = time.advanced(by: .milliseconds(10))
+        observer.afterViewDidAppear()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "parked disappear must be replayed and reported")
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not abandon the screen")
+        // `ttiEndTime` is max(screenIsReadyTime, viewDidAppearTime), so early readiness still yields 10ms.
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
+    }
+
+    func testLiveSpanStillReportsOnDisappearWithoutReadinessCall() {
+        // The supported contract: appear -> no screenIsReady -> disappear must still report, back-dating
+        // readiness to viewDidAppear. Most tracked screens get their TTI only this way.
+        let timeProvider = TimeProviderStub()
+        let time = timeProvider.time
+
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(
+            screen: UIViewController(), metricsReceiver: metricsReceiver, timeProvider: timeProvider)
+
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
+
+        timeProvider.time = time.advanced(by: .milliseconds(8))
+        observer.afterViewWillAppear()
+
+        timeProvider.time = time.advanced(by: .milliseconds(10))
+        observer.afterViewDidAppear()
+
+        timeProvider.time = time.advanced(by: .milliseconds(100))
+        observer.beforeViewWillDisappear()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.endedContexts.count, 1, "the back-dating fallback must still report")
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 0, "must not cancel a reportable one")
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.tti, .milliseconds(10))
+        XCTAssertEqual(metricsReceiver.ttiMetrics?.ttfr, .milliseconds(8))
+    }
+
+    func testCancelledScreenDoesNotOpenASecondSpan() {
+        // After a cancel `measurementHandle` is nil, so `beforeViewDidLoad`'s `measurementHandle == nil` clause
+        // is satisfied and a re-entrant call would open a second orphaned span. `ignoreThisScreen` blocks it.
+        let metricsReceiver = LiveTTIMetricsReceiverStub()
+        let observer = TTIObserver(screen: UIViewController(), metricsReceiver: metricsReceiver)
+
+        observer.beforeInit()
+        observer.beforeViewDidLoad()
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+        XCTAssertEqual(metricsReceiver.startedContexts.first?.cancelCount, 1)
+
+        observer.beforeViewDidLoad()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertEqual(metricsReceiver.startedContexts.count, 1, "must not open a second span")
+        XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
+    }
+
+    func testAbandonedScreenDoesNotStrandCustomCreationTime() {
+        // `upcomingCustomCreationTime` is a process-global consumed in `afterViewWillAppear`. If an abandoned
+        // screen skipped that, it would leak to the next screen, which reports a TTI predating its own init.
+        let timeProvider = TimeProviderStub()
+        let time = timeProvider.time
+
+        let receiverA = LiveTTIMetricsReceiverStub()
+        let observerA = TTIObserver(
+            screen: UIViewController(), metricsReceiver: receiverA, timeProvider: timeProvider)
+
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
+        waitForTheNextRunLoop()
+
+        // Abandon A: its own listener latches `wasInBackground`, so it can never report.
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        timeProvider.time = time.advanced(by: .milliseconds(150))
+        observerA.beforeInit()
+        observerA.beforeViewDidLoad()
+        timeProvider.time = time.advanced(by: .milliseconds(200))
+        observerA.afterViewWillAppear()
+        waitForTheNextRunLoop()
+
+        // B is created after the notification, so its listener never saw it and it reports normally.
+        let receiverB = LiveTTIMetricsReceiverStub()
+        let observerB = TTIObserver(
+            screen: UIViewController(), metricsReceiver: receiverB, timeProvider: timeProvider)
+
+        timeProvider.time = time.advanced(by: .milliseconds(250))
+        observerB.beforeInit()
+        observerB.beforeViewDidLoad()
+        timeProvider.time = time.advanced(by: .milliseconds(300))
+        observerB.afterViewWillAppear()
+        timeProvider.time = time.advanced(by: .milliseconds(320))
+        observerB.afterViewDidAppear()
+        timeProvider.time = time.advanced(by: .milliseconds(400))
+        observerB.screenIsReady()
+        waitForTheNextRunLoop()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertNil(receiverA.ttiMetrics, "the abandoned screen must not report")
+        XCTAssertEqual(
+            receiverB.ttiMetrics?.tti, .milliseconds(150),
+            "B must anchor at its own init (400-250), not A's stranded creation time (400-0)")
+    }
 }
 
 class TimeProviderStub: TimeProvider {

--- a/PerformanceSuite/Tests/TTIObserverTests.swift
+++ b/PerformanceSuite/Tests/TTIObserverTests.swift
@@ -583,6 +583,53 @@ class TTIObserverTests: XCTestCase {
         XCTAssertTrue(metricsReceiver.endedContexts.isEmpty)
     }
 
+    func testAbandonedScreenDoesNotStrandCustomCreationTime() {
+        // The anchor is a process-global. An abandoned screen that skipped consuming it would leak it to the
+        // next screen, which then reports a TTI predating its own init.
+        let timeProvider = TimeProviderStub()
+        let time = timeProvider.time
+
+        let appStateA = AppStateListenerStub()
+        appStateA.wasInBackground = true          // A can never report
+        let receiverA = TTIMetricsReceiverStub()
+        let observerA = TTIObserver(
+            screen: UIViewController(), metricsReceiver: receiverA,
+            timeProvider: timeProvider, appStateListener: appStateA)
+
+        TTIObserverHelper.startCustomCreationTime(timeProvider: timeProvider)
+        waitForTheNextRunLoop()
+
+        timeProvider.time = time.advanced(by: .milliseconds(150))
+        observerA.beforeInit()
+        waitForTheNextRunLoop()
+        timeProvider.time = time.advanced(by: .milliseconds(200))
+        observerA.afterViewWillAppear()
+        waitForTheNextRunLoop()
+
+        let receiverB = TTIMetricsReceiverStub()
+        let observerB = TTIObserver(
+            screen: UIViewController(), metricsReceiver: receiverB, timeProvider: timeProvider)
+
+        timeProvider.time = time.advanced(by: .milliseconds(250))
+        observerB.beforeInit()
+        waitForTheNextRunLoop()
+        timeProvider.time = time.advanced(by: .milliseconds(300))
+        observerB.afterViewWillAppear()
+        waitForTheNextRunLoop()
+        timeProvider.time = time.advanced(by: .milliseconds(320))
+        observerB.afterViewDidAppear()
+        waitForTheNextRunLoop()
+        timeProvider.time = time.advanced(by: .milliseconds(400))
+        observerB.screenIsReady()
+        waitForTheNextRunLoop()
+        PerformanceMonitoring.consumerQueue.sync {}
+
+        XCTAssertNil(receiverA.ttiMetrics, "the abandoned screen must not report")
+        XCTAssertEqual(
+            receiverB.ttiMetrics?.tti, .milliseconds(150),
+            "B must anchor at its own init (400-250), not A's stranded anchor (400-0)")
+    }
+
     func testLiveSpanStillReportsOnDisappearWithoutReadinessCall() {
         // Characterisation pin: this leaves `beforeViewWillDisappear` untouched, and it is how most tracked
         // screens get their TTI at all.

--- a/PerformanceSuite/Tests/Utils/TTIMetricsReceiverStub.swift
+++ b/PerformanceSuite/Tests/Utils/TTIMetricsReceiverStub.swift
@@ -7,6 +7,7 @@
 
 import PerformanceSuite
 import UIKit
+import XCTest
 
 class TTIMetricsReceiverStub: TTIMetricsReceiver {
 
@@ -34,4 +35,41 @@ class TTIMetricsReceiverStub: TTIMetricsReceiver {
     var ttiCallback: (TTIMetrics, UIViewController) -> Void = { (_, _) in }
     var ttiMetrics: TTIMetrics?
     var lastController: UIViewController?
+}
+
+/// Live TTI receiver double. Modelled on `LiveRenderingMetricsReceiverStub` in `RenderingObserverTests`.
+final class LiveTTIMetricsReceiverStub: LiveTTIMetricsReceiver {
+
+    final class StubContext: MeasurementHandle {
+        var cancelCount = 0
+        func cancel() { cancelCount += 1 }
+    }
+
+    var startedContexts: [StubContext] = []
+    var endedContexts: [(any MeasurementHandle)?] = []
+    var ttiMetrics: TTIMetrics?
+
+    func screenIdentifier(for viewController: UIViewController) -> UIViewController? {
+        return viewController
+    }
+
+    func ttiMetricsReceived(metrics: TTIMetrics, screen: UIViewController) {
+        // A live receiver always resolves to `screenTTIMeasurementEnded`; the plain callback must not fire.
+        XCTFail("ttiMetricsReceived should not fire for a live receiver")
+    }
+
+    func screenTTIMeasurementStarted(screen: UIViewController) -> (any MeasurementHandle)? {
+        let context = StubContext()
+        startedContexts.append(context)
+        return context
+    }
+
+    func screenTTIMeasurementEnded(
+        metrics: TTIMetrics,
+        screen: UIViewController,
+        context: (any MeasurementHandle)?
+    ) {
+        endedContexts.append(context)
+        ttiMetrics = metrics
+    }
 }


### PR DESCRIPTION
TTIObserver opens a live measurement in beforeViewDidLoad but had no unconditional path that closes it. Every terminal path was gated, and when a gate closed the function returned without cancelling — so the span was left for backend auto-termination with no screen.tti.ms, and stayed eligible as an ambient parent for outbound network spans in the meantime.

This is an incomplete retrofit rather than an original design flaw. The live handle arrived in 29934c1, onto a state machine written when an unresolvable TTI simply returned, which was a complete outcome holding no resource. That commit wired cancelMeasurement only to paths that were already explicit branches. Three days later 9e3c9f2 fixed the same class for rendering; TTI was skipped, and FragmentTTIReporter already carries the wasInBackground branch.

- beforeViewWillDisappear moves its body to processDisappear() and cancels instead of returning silently when no metric can ever be produced.
- Parking mirrors RenderingObserver. The swizzler defers viewWillAppear and viewDidAppear through main.async but calls viewWillDisappear directly, so a same-turn push-then-pop delivers the disappear first; reading the still-nil viewDidAppearTime as "never appeared" would abandon a measurable screen.
- willResignActive cancels, deliberately ungated. DefaultAppStateListener registers its own observer in init, which runs as this observer's default argument and therefore first, so wasInBackground is already true by the time the handler runs and a gated version would be dead code. No didBecomeActive restart, because TTI is one-shot.
- upcomingCustomCreationTime is consumed exactly once on the first viewWillAppear, even when the measurement is already abandoned. Previously an abandoned screen stranded the process-global and the next screen reported a TTI anchored before its own init.
- Adds LiveTTIMetricsReceiverStub. TTIMetricsReceiverStub is not live and TTIObserver resolves the live receiver by conditional cast, so every existing TTI test took the non-live branch and the handle lifecycle was untested — which is how this shipped through 1.10.x and 1.11.x. Each new test was verified to fail when its own defect is reintroduced.

One deliberate behaviour change: the inverted-order case with no readiness call now reports where it previously reported nothing. That is a correctness improvement, and the same choice RenderingObserver already made.