### PR TITLE
Resolve the simulator destination instead of pinning a runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,12 +115,13 @@ jobs:
       - name: Run Unit Tests
         env:
           scheme: UnitTests
-          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
+          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |
           set -e
           echo "Starting unit tests with destination: $destination"
+          xcrun simctl list runtimes | grep -i "^iOS" || true
           xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UnitTestResults.xcresult
           echo "Unit tests completed successfully"
 
@@ -202,12 +203,13 @@ jobs:
       - name: Run UI Tests
         env:
           scheme: UITests
-          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1
+          destination: platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
           workspace: Project.xcworkspace
         timeout-minutes: 30
         run: |
           set -e
           echo "Starting UI tests with destination: $destination"
+          xcrun simctl list runtimes | grep -i "^iOS" || true
           xcodebuild test -scheme "$scheme" -workspace "$workspace" -destination "$destination" -derivedDataPath DerivedData -resultBundlePath UITestResults.xcresult SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) PERFORMANCE_TESTS'
           echo "UI tests completed successfully"
 


### PR DESCRIPTION
Both test jobs hardcoded OS=26.4.1. The runner image has since moved to Xcode 26.6, which does not carry that runtime, so xcodebuild fails to find any destination and lists only placeholders. main last ran green on 2026-07-01, so this surfaced on the first PR after the image drifted rather than on a change.

OS=latest resolves against whatever the image provides. Both jobs now also log the installed iOS runtimes, so a future drift is visible in the log rather than only in a failure.

Note xcode-version is pinned to 26.0 but the runner reported Xcode 26.6 — the setup action appears to prefix-match. Left alone here; worth deciding separately whether the intent is a floor or an exact version.